### PR TITLE
Add support for ignoring unknown SAML attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Developed as part of the [SURFnet StepUp Gateway][2]
 ```yaml
 surfnet_saml:
     hosted:
+        attribute_dictionary:
+            ignore_unknown_attributes: false
         service_provider:
             enabled: true
             assertion_consumer_route: name_of_the_route_of_the_assertion_consumer_url

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -52,6 +52,18 @@ class Configuration implements ConfigurationInterface
             ->children()
             ->arrayNode('hosted')
                 ->children()
+                    ->arrayNode('attribute_dictionary')
+                        ->canBeEnabled()
+                        ->children()
+                            ->booleanNode('ignore_unknown_attributes')
+                            ->defaultFalse()
+                            ->info(
+                                'If the IDP provides atttributes which are not in the dictionary the SAML assertion'
+                                . 'will fail with an UnknownUrnException. Unless this value is true.'
+                            )
+                            ->end()
+                        ->end()
+                    ->end()
                     ->arrayNode('service_provider')
                         ->canBeEnabled()
                         ->children()

--- a/src/DependencyInjection/SurfnetSamlExtension.php
+++ b/src/DependencyInjection/SurfnetSamlExtension.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\SamlBundle\DependencyInjection;
 
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
@@ -51,6 +52,10 @@ class SurfnetSamlExtension extends Extension
         $entityId = ['entity_id_route' => $configuration['metadata']['entity_id_route']];
         $serviceProvider  = array_merge($configuration['service_provider'], $entityId);
         $identityProvider = array_merge($configuration['identity_provider'], $entityId);
+
+        $container
+            ->getDefinition('surfnet_saml.saml.attribute_dictionary')
+            ->replaceArgument(0, $configuration['attribute_dictionary']['ignore_unknown_attributes']);
 
         $this->parseHostedSpConfiguration($serviceProvider, $container);
         $this->parseHostedIdpConfiguration($identityProvider, $container);

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,6 +1,8 @@
 services:
     surfnet_saml.saml.attribute_dictionary:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary
+        arguments:
+            - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
 
     surfnet_saml.configuration.metadata:
         class: Surfnet\SamlBundle\Metadata\MetadataConfiguration

--- a/src/SAML2/Attribute/AttributeDictionary.php
+++ b/src/SAML2/Attribute/AttributeDictionary.php
@@ -37,6 +37,33 @@ class AttributeDictionary
     private $attributeDefinitionsByUrn = [];
 
     /**
+     * Ignore unknown attributes coming from the IDP
+     *
+     * @var bool
+     */
+    private $ignoreUnknowAttributes = false;
+
+    /**
+     * AttributeDictionary constructor.
+     *
+     * @param bool $ignoreUnknowAttributes
+     */
+    public function __construct($ignoreUnknowAttributes = false)
+    {
+        $this->ignoreUnknowAttributes = $ignoreUnknowAttributes;
+    }
+
+    /**
+     * Whether to ignore unknown SAML attributes.
+     *
+     * @return bool
+     */
+    public function ignoreUnknownAttributes()
+    {
+        return $this->ignoreUnknowAttributes;
+    }
+
+    /**
      * @param AttributeDefinition $attributeDefinition
      *
      * We store the definitions indexed both by name and by urn to ensure speedy lookups due to the amount of

--- a/src/SAML2/Attribute/AttributeSet.php
+++ b/src/SAML2/Attribute/AttributeSet.php
@@ -21,6 +21,7 @@ namespace Surfnet\SamlBundle\SAML2\Attribute;
 use ArrayIterator;
 use SAML2_Assertion;
 use Surfnet\SamlBundle\Exception\RuntimeException;
+use Surfnet\SamlBundle\Exception\UnknownUrnException;
 use Surfnet\SamlBundle\SAML2\Attribute\Filter\AttributeFilter;
 
 class AttributeSet implements AttributeSetFactory, AttributeSetInterface
@@ -35,8 +36,17 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
         $attributeSet = new AttributeSet();
 
         foreach ($assertion->getAttributes() as $urn => $attributeValue) {
-            $attribute = new Attribute($attributeDictionary->getAttributeDefinitionByUrn($urn), $attributeValue);
-            $attributeSet->initializeWith($attribute);
+            try {
+                $attribute = new Attribute(
+                    $attributeDictionary->getAttributeDefinitionByUrn($urn),
+                    $attributeValue
+                );
+                $attributeSet->initializeWith($attribute);
+            } catch (UnknownUrnException $e) {
+                if (!$attributeDictionary->ignoreUnknownAttributes()) {
+                    throw $e;
+                }
+            }
         }
 
         return $attributeSet;

--- a/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\SamlBundle\Exception\UnknownUrnException;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 
@@ -142,5 +143,46 @@ class AttributeDictionaryTest extends TestCase
             $foundDefinition,
             'Expected to find an attribute definition, but found none'
         );
+    }
+
+    /**
+     * @test
+     * @group AttributeDictionary
+     * @expectedException \Surfnet\SamlBundle\Exception\UnknownUrnException
+     */
+    public function shouldThrowExceptionForUnknownAttrib()
+    {
+        $oidAttributeUrn = 'urn:oid:0.0.0.0.0.0.0.0.0';
+
+        $existingOidAttributeDefinition = new AttributeDefinition(
+            'existingOidAttribute',
+            'urn:mace:some:attribute',
+            $oidAttributeUrn
+        );
+        $attributeDictionary = new AttributeDictionary();
+        $attributeDictionary->addAttributeDefinition($existingOidAttributeDefinition);
+        $attributeDictionary->getAttributeDefinitionByUrn('unknown:0.0.0.0.0');
+    }
+
+    /**
+     * @test
+     * @group AttributeDictionary
+     */
+    public function shouldIgnoreUnknownAttributes()
+    {
+        $attributeDictionary = new AttributeDictionary(true);
+        $this->assertTrue($attributeDictionary->ignoreUnknownAttributes());
+    }
+
+    /**
+     * @test
+     * @group AttributeDictionary
+     */
+    public function shouldNotIgnoreUnknownAttributes()
+    {
+        $attributeDictionary = new AttributeDictionary();
+        $this->assertFalse($attributeDictionary->ignoreUnknownAttributes());
+        $attributeDictionary = new AttributeDictionary(false);
+        $this->assertFalse($attributeDictionary->ignoreUnknownAttributes());
     }
 }


### PR DESCRIPTION
Prior to this change a SAML assertion could fail when the IdP returned
unknown attributes. This leads in an unhandled exception which resulted
in an application/php error.

By enabling the configuration directive "ignore_unknown_attributes" in the
hosted->attribute_dictionary unknown attibutes are ignored. The SAML assertion
will continue and only the values of the known attributes are available.
See README.md for the configuration details.
The configuration defaults to the previous behavior in which
an assertion fails when encountering an unknown SAML attribute.