### PR TITLE
Add the eduPersonOrcid attribute to config

### DIFF
--- a/src/Resources/config/saml_attributes.yml
+++ b/src/Resources/config/saml_attributes.yml
@@ -278,6 +278,15 @@ services:
         tags:
             - { name: 'saml.attribute' }
 
+    saml.attribute.eduPersonOrcid:
+        class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
+        arguments:
+            - eduPersonOrcid
+            - 'urn:mace:dir:attribute-def:eduPersonOrcid'
+            - 'urn:oid:1.3.6.1.4.1.5923.1.1.1.16'
+        tags:
+            - { name: 'saml.attribute' }
+
     saml.attribute.audio:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
         arguments:


### PR DESCRIPTION
  The eduPersonOrcid attribute definition was added to the `saml_attributes.yml` config.