### PR TITLE
SAML2 & XMLSecLibs upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
     "require": {
         "php": ">=5.4,<8.0-dev",
         "ext-openssl": "*",
-        "simplesamlphp/saml2": "^1.8",
+        "simplesamlphp/saml2": "^3.0",
         "symfony/dependency-injection": ">=2.7,<4",
         "symfony/framework-bundle": ">=2.7,<4",
-        "robrichards/xmlseclibs": "^1.4.0"
+        "robrichards/xmlseclibs": "^3.0"
     },
     "require-dev": {
         "ibuildings/qa-tools": "~1.1",

--- a/src/Entity/HostedEntities.php
+++ b/src/Entity/HostedEntities.php
@@ -21,7 +21,7 @@ namespace Surfnet\SamlBundle\Entity;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
-use SAML2_Configuration_PrivateKey as PrivateKey;
+use SAML2\Configuration\PrivateKey;
 
 class HostedEntities
 {

--- a/src/Entity/IdentityProvider.php
+++ b/src/Entity/IdentityProvider.php
@@ -18,7 +18,9 @@
 
 namespace Surfnet\SamlBundle\Entity;
 
-class IdentityProvider extends \SAML2_Configuration_IdentityProvider
+use SAML2\Configuration\IdentityProvider as IdentityProviderConfiguration;
+
+class IdentityProvider extends IdentityProviderConfiguration
 {
     public function getSsoUrl()
     {

--- a/src/Entity/ServiceProvider.php
+++ b/src/Entity/ServiceProvider.php
@@ -18,7 +18,9 @@
 
 namespace Surfnet\SamlBundle\Entity;
 
-class ServiceProvider extends \SAML2_Configuration_ServiceProvider
+use SAML2\Configuration\ServiceProvider as ServiceProviderConfiguration;
+
+class ServiceProvider extends ServiceProviderConfiguration
 {
     public function getAssertionConsumerUrl()
     {

--- a/src/Http/Exception/AuthnFailedSamlResponseException.php
+++ b/src/Http/Exception/AuthnFailedSamlResponseException.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Http\Exception;
 
-use SAML2_Response_Exception_PreconditionNotMetException as PreconditionNotMetException;
+use SAML2\Response\Exception\PreconditionNotMetException;
 use Surfnet\SamlBundle\Exception\Exception;
 
 class AuthnFailedSamlResponseException extends PreconditionNotMetException implements Exception

--- a/src/Http/Exception/NoAuthnContextSamlResponseException.php
+++ b/src/Http/Exception/NoAuthnContextSamlResponseException.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Http\Exception;
 
-use SAML2_Response_Exception_PreconditionNotMetException as PreconditionNotMetException;
+use SAML2\Response\Exception\PreconditionNotMetException;
 use Surfnet\SamlBundle\Exception\Exception;
 
 class NoAuthnContextSamlResponseException extends PreconditionNotMetException implements Exception

--- a/src/Http/ReceivedAuthnRequestPost.php
+++ b/src/Http/ReceivedAuthnRequestPost.php
@@ -18,10 +18,9 @@
 
 namespace Surfnet\SamlBundle\Http;
 
-use Surfnet\SamlBundle\Exception\RuntimeException;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 use Surfnet\SamlBundle\Http\Exception\InvalidRequestException;
 use Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest;
-use XMLSecurityKey;
 
 final class ReceivedAuthnRequestPost implements SignatureVerifiable
 {

--- a/src/Http/ReceivedAuthnRequestPost.php
+++ b/src/Http/ReceivedAuthnRequestPost.php
@@ -112,7 +112,7 @@ final class ReceivedAuthnRequestPost implements SignatureVerifiable
     /**
      * @param XMLSecurityKey $key
      * @return bool
-     * @throws \Exception when signature is invalid (@see SAML2_Utils::validateSignature)
+     * @throws \Exception when signature is invalid (@see SAML2\Utils::validateSignature)
      */
     public function verify(XMLSecurityKey $key)
     {

--- a/src/Http/ReceivedAuthnRequestQueryString.php
+++ b/src/Http/ReceivedAuthnRequestQueryString.php
@@ -18,11 +18,11 @@
 
 namespace Surfnet\SamlBundle\Http;
 
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 use Surfnet\SamlBundle\Exception\LogicException;
 use Surfnet\SamlBundle\Exception\RuntimeException;
 use Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException;
 use Surfnet\SamlBundle\Http\Exception\InvalidRequestException;
-use XMLSecurityKey;
 
 final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
 {

--- a/src/Http/RedirectBinding.php
+++ b/src/Http/RedirectBinding.php
@@ -19,6 +19,7 @@
 namespace Surfnet\SamlBundle\Http;
 
 use Psr\Log\LoggerInterface;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 use Surfnet\SamlBundle\Entity\ServiceProviderRepository;
 use Surfnet\SamlBundle\Exception\LogicException;
 use Surfnet\SamlBundle\Http\Exception\UnknownServiceProviderException;
@@ -29,7 +30,6 @@ use Surfnet\SamlBundle\Signing\SignatureVerifier;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use XMLSecurityKey;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) - not much we can do about it

--- a/src/Http/RedirectBinding.php
+++ b/src/Http/RedirectBinding.php
@@ -43,7 +43,7 @@ class RedirectBinding implements HttpBinding
     private $logger;
 
     /**
-     * @var \SAML2_Certificate_KeyLoader
+     * @var \SAML2\Certificate\KeyLoader
      */
     private $signatureVerifier;
 

--- a/src/Http/SignatureVerifiable.php
+++ b/src/Http/SignatureVerifiable.php
@@ -18,8 +18,7 @@
 
 namespace Surfnet\SamlBundle\Http;
 
-
-use XMLSecurityKey;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 interface SignatureVerifiable
 {

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -18,9 +18,10 @@
 
 namespace Surfnet\SamlBundle\Metadata;
 
-use SAML2_DOMDocumentFactory;
-use SAML2_Utilities_Certificate;
-use SAML2_Utilities_File;
+use SAML2\Certificate\PrivateKeyLoader;
+use SAML2\DOMDocumentFactory;
+use SAML2\Utilities\Certificate;
+use SAML2\Utilities\File;
 use Surfnet\SamlBundle\Service\SigningService;
 use Surfnet\SamlBundle\Signing\KeyPair;
 use Symfony\Component\Routing\RouterInterface;
@@ -39,7 +40,7 @@ class MetadataFactory
     private $router;
 
     /**
-     * @var \SAML2_Certificate_PrivateKeyLoader
+     * @var PrivateKeyLoader
      */
     private $signingService;
 
@@ -85,7 +86,7 @@ class MetadataFactory
         $metadata = $this->getMetadata();
         $keyPair = $this->buildKeyPairFrom($this->metadataConfiguration);
 
-        $metadata->document = SAML2_DOMDocumentFactory::create();
+        $metadata->document = DOMDocumentFactory::create();
         $metadata->document->loadXML($this->templateEngine->render(
             'SurfnetSamlBundle:Metadata:metadata.xml.twig',
             ['metadata' => $metadata]
@@ -146,8 +147,8 @@ class MetadataFactory
      */
     private function getCertificateData($publicKeyFile)
     {
-        $certificate = SAML2_Utilities_File::getFileContents($publicKeyFile);
-        preg_match(SAML2_Utilities_Certificate::CERTIFICATE_PATTERN, $certificate, $matches);
+        $certificate = File::getFileContents($publicKeyFile);
+        preg_match(Certificate::CERTIFICATE_PATTERN, $certificate, $matches);
 
         $certificateData = str_replace(array(' ', "\n"), '', $matches[1]);
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -72,15 +72,15 @@ services:
 
     surfnet_saml.saml2.keyloader:
         public: false
-        class: SAML2_Certificate_KeyLoader
+        class: SAML2\Certificate\KeyLoader
 
     surfnet_saml.saml2.privatekeyloader:
         public: false
-        class: SAML2_Certificate_PrivateKeyLoader
+        class: SAML2\Certificate\PrivateKeyLoader
 
     surfnet_saml.saml2.response_processor:
         public: false
-        class: SAML2_Response_Processor
+        class: SAML2\Response\Processor
         arguments:
             - '@logger'
 

--- a/src/SAML2/Attribute/AttributeDictionary.php
+++ b/src/SAML2/Attribute/AttributeDictionary.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\SAML2\Attribute;
 
-use SAML2_Assertion;
+use SAML2\Assertion;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\Exception\LogicException;
 use Surfnet\SamlBundle\Exception\UnknownUrnException;
@@ -90,10 +90,10 @@ class AttributeDictionary
     }
 
     /**
-     * @param SAML2_Assertion $assertion
+     * @param Assertion $assertion
      * @return AssertionAdapter
      */
-    public function translate(SAML2_Assertion $assertion)
+    public function translate(Assertion $assertion)
     {
         return new AssertionAdapter($assertion, $this);
     }

--- a/src/SAML2/Attribute/AttributeSet.php
+++ b/src/SAML2/Attribute/AttributeSet.php
@@ -19,7 +19,7 @@
 namespace Surfnet\SamlBundle\SAML2\Attribute;
 
 use ArrayIterator;
-use SAML2_Assertion;
+use SAML2\Assertion;
 use Surfnet\SamlBundle\Exception\RuntimeException;
 use Surfnet\SamlBundle\Exception\UnknownUrnException;
 use Surfnet\SamlBundle\SAML2\Attribute\Filter\AttributeFilter;
@@ -31,7 +31,7 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
      */
     private $attributes = [];
 
-    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
+    public static function createFrom(Assertion $assertion, AttributeDictionary $attributeDictionary)
     {
         $attributeSet = new AttributeSet();
 

--- a/src/SAML2/Attribute/AttributeSetFactory.php
+++ b/src/SAML2/Attribute/AttributeSetFactory.php
@@ -18,18 +18,18 @@
 
 namespace Surfnet\SamlBundle\SAML2\Attribute;
 
-use SAML2_Assertion;
+use SAML2\Assertion;
 
 interface AttributeSetFactory
 {
     /**
-     * @param SAML2_Assertion $assertion
+     * @param Assertion $assertion
      * @param AttributeDictionary $attributeDictionary
      * @return AttributeSet
      *
      * @deprecated Will be replaced with different creation implementation
      */
-    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary);
+    public static function createFrom(Assertion $assertion, AttributeDictionary $attributeDictionary);
 
     /**
      * @param Attribute[] $attributes

--- a/src/SAML2/Attribute/ConfigurableAttributeSetFactory.php
+++ b/src/SAML2/Attribute/ConfigurableAttributeSetFactory.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\SAML2\Attribute;
 
-use SAML2_Assertion;
+use SAML2\Assertion;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 
 final class ConfigurableAttributeSetFactory implements AttributeSetFactory
@@ -45,7 +45,7 @@ final class ConfigurableAttributeSetFactory implements AttributeSetFactory
         self::$attributeSetClassName = $attributeSetClassName;
     }
 
-    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
+    public static function createFrom(Assertion $assertion, AttributeDictionary $attributeDictionary)
     {
         $class = self::$attributeSetClassName;
 

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -18,8 +18,8 @@
 
 namespace Surfnet\SamlBundle\SAML2;
 
-use SAML2_AuthnRequest;
-use SAML2_Const;
+use SAML2\AuthnRequest as SAML2AuthnRequest;
+use SAML2\Constants;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 
 class AuthnRequest
@@ -35,7 +35,7 @@ class AuthnRequest
     private $rawRequest;
 
     /**
-     * @var SAML2_AuthnRequest
+     * @var SAML2AuthnRequest
      */
     private $request;
 
@@ -50,22 +50,22 @@ class AuthnRequest
     private $signatureAlgorithm;
 
     /**
-     * @param SAML2_AuthnRequest $request
+     * @param SAML2AuthnRequest $request
      */
-    private function __construct(SAML2_AuthnRequest $request)
+    private function __construct(SAML2AuthnRequest $request)
     {
         $this->request = $request;
     }
 
     /**
      * @deprecated use ReceivedAuthnRequest::from()
-     * @param SAML2_AuthnRequest $request
+     * @param SAML2AuthnRequest $request
      * @param string $rawRequest
      * @param string $relayState
      * @return AuthnRequest
      */
     public static function createUnsigned(
-        SAML2_AuthnRequest $request,
+        SAML2AuthnRequest $request,
         $rawRequest,
         $relayState
     ) {
@@ -80,7 +80,7 @@ class AuthnRequest
 
     /**
      * @deprecated use ReceivedAuthnRequest::from()
-     * @param SAML2_AuthnRequest $request
+     * @param SAML2AuthnRequest $request
      * @param string $rawRequest
      * @param string $relayState
      * @param string $signature
@@ -88,7 +88,7 @@ class AuthnRequest
      * @return AuthnRequest
      */
     public static function createSigned(
-        SAML2_AuthnRequest $request,
+        SAML2AuthnRequest $request,
         $rawRequest,
         $relayState,
         $signature,
@@ -107,7 +107,7 @@ class AuthnRequest
 
     /**
      * @deprecated use ReceivedAuthnRequest::from()
-     * @param SAML2_AuthnRequest $request
+     * @param SAML2AuthnRequest $request
      * @param string $rawRequest
      * @param string $relayState
      * @param string $signature
@@ -115,7 +115,7 @@ class AuthnRequest
      * @return AuthnRequest
      */
     public static function create(
-        SAML2_AuthnRequest $request,
+        SAML2AuthnRequest $request,
         $rawRequest,
         $relayState,
         $signature,
@@ -130,7 +130,7 @@ class AuthnRequest
         );
     }
 
-    public static function createNew(SAML2_AuthnRequest $req)
+    public static function createNew(SAML2AuthnRequest $req)
     {
         return new self($req);
     }
@@ -164,11 +164,8 @@ class AuthnRequest
     public function getNameId()
     {
         $nameId = $this->request->getNameId();
-        if (!is_array($nameId) || !array_key_exists('Value', $nameId)) {
-            return null;
-        }
 
-        return $nameId['Value'];
+        return $nameId->value;
     }
 
     /**
@@ -177,11 +174,8 @@ class AuthnRequest
     public function getNameIdFormat()
     {
         $nameId = $this->request->getNameId();
-        if (!is_array($nameId) || !array_key_exists('Format', $nameId)) {
-            return null;
-        }
 
-        return $nameId['Format'];
+        return $nameId->Format;
     }
 
     /**
@@ -200,7 +194,7 @@ class AuthnRequest
 
         $nameId = [
             'Value' => $nameId,
-            'Format' => ($format ?: SAML2_Const::NAMEID_UNSPECIFIED)
+            'Format' => ($format ?: Constants::NAMEID_UNSPECIFIED)
         ];
 
         $this->request->setNameId($nameId);

--- a/src/SAML2/BridgeContainer.php
+++ b/src/SAML2/BridgeContainer.php
@@ -20,13 +20,13 @@ namespace Surfnet\SamlBundle\SAML2;
 
 use BadMethodCallException;
 use Psr\Log\LoggerInterface;
-use SAML2_Compat_AbstractContainer;
+use SAML2\Compat\AbstractContainer;
 
 /**
  * Container that is required so that we can make the SAML2 lib work.
  * This container is set as the container in the SurfnetSamlBundle::boot() method
  */
-class BridgeContainer extends SAML2_Compat_AbstractContainer
+class BridgeContainer extends AbstractContainer
 {
     /**
      * @var \Psr\Log\LoggerInterface

--- a/src/SAML2/ReceivedAuthnRequest.php
+++ b/src/SAML2/ReceivedAuthnRequest.php
@@ -18,22 +18,22 @@
 
 namespace Surfnet\SamlBundle\SAML2;
 
-use SAML2_AuthnRequest;
-use SAML2_Const;
-use SAML2_DOMDocumentFactory;
-use SAML2_Message;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\AuthnRequest as SAML2AuthnRequest;
+use SAML2\Constants;
+use SAML2\DOMDocumentFactory;
+use SAML2\Message;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\Exception\RuntimeException;
-use XMLSecurityKey;
 
 final class ReceivedAuthnRequest
 {
     /**
-     * @var SAML2_AuthnRequest
+     * @var SAML2AuthnRequest
      */
     private $request;
 
-    private function __construct(SAML2_AuthnRequest $request)
+    private function __construct(SAML2AuthnRequest $request)
     {
         $this->request = $request;
     }
@@ -53,12 +53,12 @@ final class ReceivedAuthnRequest
 
         // additional security against XXE Processing vulnerability
         $previous = libxml_disable_entity_loader(true);
-        $document = SAML2_DOMDocumentFactory::fromString($decodedSamlRequest);
+        $document = DOMDocumentFactory::fromString($decodedSamlRequest);
         libxml_disable_entity_loader($previous);
 
-        $authnRequest = SAML2_Message::fromXML($document->firstChild);
+        $authnRequest = Message::fromXML($document->firstChild);
 
-        if (!$authnRequest instanceof SAML2_AuthnRequest) {
+        if (!$authnRequest instanceof SAML2AuthnRequest) {
             throw new RuntimeException(sprintf(
                 'The received request is not an AuthnRequest, "%s" received instead',
                 substr(get_class($authnRequest), strrpos($authnRequest, '_') + 1)
@@ -133,7 +133,7 @@ final class ReceivedAuthnRequest
 
         $nameId = [
             'Value' => $nameId,
-            'Format' => ($format ?: SAML2_Const::NAMEID_UNSPECIFIED)
+            'Format' => ($format ?: Constants::NAMEID_UNSPECIFIED)
         ];
 
         $this->request->setNameId($nameId);
@@ -208,7 +208,7 @@ final class ReceivedAuthnRequest
     /**
      * @param XMLSecurityKey $key
      * @return bool
-     * @throws \Exception when signature is invalid (@see SAML2_Utils::validateSignature)
+     * @throws \Exception when signature is invalid (@see SAML2\Utils::validateSignature)
      */
     public function verify(XMLSecurityKey $key)
     {

--- a/src/SAML2/Response/Assertion/InResponseTo.php
+++ b/src/SAML2/Response/Assertion/InResponseTo.php
@@ -18,16 +18,16 @@
 
 namespace Surfnet\SamlBundle\SAML2\Response\Assertion;
 
-use SAML2_Assertion;
+use SAML2\Assertion;
 
 class InResponseTo
 {
     /**
-     * @param SAML2_Assertion $assertion
-     * @param string          $inResponseTo
+     * @param Assertion $assertion
+     * @param string    $inResponseTo
      * @return bool
      */
-    public static function assertEquals(SAML2_Assertion $assertion, $inResponseTo)
+    public static function assertEquals(Assertion $assertion, $inResponseTo)
     {
         $assertionInResponseTo = static::getInResponseTo($assertion);
 
@@ -35,10 +35,10 @@ class InResponseTo
     }
 
     /**
-     * @param SAML2_Assertion $assertion
+     * @param Assertion $assertion
      * @return null|string
      */
-    private static function getInResponseTo(SAML2_Assertion $assertion)
+    private static function getInResponseTo(Assertion $assertion)
     {
         $subjectConfirmationArray = $assertion->getSubjectConfirmation();
 
@@ -46,7 +46,7 @@ class InResponseTo
             return null;
         }
 
-        /** @var \SAML2_XML_saml_SubjectConfirmation $subjectConfirmation */
+        /** @var \SAML2\XML\saml\SubjectConfirmation $subjectConfirmation */
         $subjectConfirmation = $subjectConfirmationArray[0];
         if (!$subjectConfirmation->SubjectConfirmationData) {
             return null;

--- a/src/SAML2/Response/AssertionAdapter.php
+++ b/src/SAML2/Response/AssertionAdapter.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\SAML2\Response;
 
-use SAML2_Assertion;
+use SAML2\Assertion;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetInterface;
 use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
@@ -26,7 +26,7 @@ use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
 class AssertionAdapter
 {
     /**
-     * @var SAML2_Assertion
+     * @var Assertion
      */
     private $assertion;
 
@@ -40,7 +40,7 @@ class AssertionAdapter
      */
     private $attributeDictionary;
 
-    public function __construct(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
+    public function __construct(Assertion $assertion, AttributeDictionary $attributeDictionary)
     {
         $this->assertion           = $assertion;
         $this->attributeSet        = ConfigurableAttributeSetFactory::createFrom($assertion, $attributeDictionary);

--- a/src/Service/SigningService.php
+++ b/src/Service/SigningService.php
@@ -18,25 +18,25 @@
 
 namespace Surfnet\SamlBundle\Service;
 
-use SAML2_Certificate_KeyLoader as PublicKeyLoader;
-use SAML2_Certificate_PrivateKey;
-use SAML2_Certificate_PrivateKeyLoader as PrivateKeyLoader;
-use SAML2_Certificate_X509;
-use SAML2_Configuration_PrivateKey as PrivateKeyFile;
-use SAML2_Utils;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Certificate\KeyLoader as PublicKeyLoader;
+use SAML2\Certificate\PrivateKey;
+use SAML2\Certificate\PrivateKeyLoader;
+use SAML2\Certificate\X509;
+use SAML2\Configuration\PrivateKey as PrivateKeyFile;
+use SAML2\Utils;
 use Surfnet\SamlBundle\Signing\KeyPair;
 use Surfnet\SamlBundle\Signing\Signable;
-use XMLSecurityKey;
 
 class SigningService
 {
     /**
-     * @var \SAML2_Certificate_KeyLoader
+     * @var KeyLoader
      */
     private $publicKeyLoader;
 
     /**
-     * @var \SAML2_Certificate_PrivateKeyLoader
+     * @var PrivateKeyLoader
      */
     private $privateKeyLoader;
 
@@ -64,7 +64,7 @@ class SigningService
         $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
         $key->loadKey($privateKey->getKeyAsString());
 
-        SAML2_Utils::insertSignature(
+        Utils::insertSignature(
             $key,
             [$publicKey->getCertificate()],
             $signable->getRootDomElement(),
@@ -76,7 +76,7 @@ class SigningService
 
     /**
      * @param  string $publicKeyFile /full/path/to/the/public/key
-     * @return SAML2_Certificate_X509
+     * @return X509
      */
     public function loadPublicKeyFromFile($publicKeyFile)
     {
@@ -92,7 +92,7 @@ class SigningService
 
     /**
      * @param  string $privateKeyFile /full/path/to/the/private/key
-     * @return SAML2_Certificate_PrivateKey
+     * @return PrivateKey
      */
     public function loadPrivateKeyFromFile($privateKeyFile)
     {

--- a/src/Signing/SignatureVerifier.php
+++ b/src/Signing/SignatureVerifier.php
@@ -19,19 +19,19 @@
 namespace Surfnet\SamlBundle\Signing;
 
 use Psr\Log\LoggerInterface;
-use SAML2_Certificate_Key;
-use SAML2_Certificate_KeyLoader as KeyLoader;
-use SAML2_Certificate_X509;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Certificate\Key;
+use SAML2\Certificate\KeyLoader as KeyLoader;
+use SAML2\Certificate\X509;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestQueryString;
 use Surfnet\SamlBundle\Http\SignatureVerifiable;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
-use XMLSecurityKey;
 
 class SignatureVerifier
 {
     /**
-     * @var \SAML2_Certificate_KeyLoader
+     * @var KeyLoader
      */
     private $keyLoader;
 
@@ -57,8 +57,8 @@ class SignatureVerifier
         $keys = $this->keyLoader->extractPublicKeys($serviceProvider);
 
         $this->logger->debug(sprintf('Found "%d" keys, filtering the keys to get X509 keys', $keys->count()));
-        $x509Keys = $keys->filter(function (SAML2_Certificate_Key $key) {
-            return $key instanceof SAML2_Certificate_X509;
+        $x509Keys = $keys->filter(function (Key $key) {
+            return $key instanceof X509;
         });
 
         $this->logger->debug(sprintf(
@@ -79,10 +79,10 @@ class SignatureVerifier
 
     /**
      * @param SignatureVerifiable $request
-     * @param SAML2_Certificate_X509 $publicKey
+     * @param X509 $publicKey
      * @return bool
      */
-    public function isRequestSignedWith(SignatureVerifiable $request, SAML2_Certificate_X509 $publicKey)
+    public function isRequestSignedWith(SignatureVerifiable $request, X509 $publicKey)
     {
         $this->logger->debug(sprintf('Attempting to verify signature with certificate "%s"', $publicKey->getCertificate()));
         $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
@@ -110,8 +110,8 @@ class SignatureVerifier
         $keys = $this->keyLoader->extractPublicKeys($serviceProvider);
 
         $this->logger->debug(sprintf('Found "%d" keys, filtering the keys to get X509 keys', $keys->count()));
-        $x509Keys = $keys->filter(function (SAML2_Certificate_Key $key) {
-            return $key instanceof SAML2_Certificate_X509;
+        $x509Keys = $keys->filter(function (Key $key) {
+            return $key instanceof X509;
         });
 
         $this->logger->debug(sprintf(
@@ -132,11 +132,11 @@ class SignatureVerifier
 
     /**
      * @param AuthnRequest           $request
-     * @param SAML2_Certificate_X509 $publicKey
+     * @param X509 $publicKey
      * @return bool
      * @throws \Exception
      */
-    public function isSignedWith(AuthnRequest $request, SAML2_Certificate_X509 $publicKey)
+    public function isSignedWith(AuthnRequest $request, X509 $publicKey)
     {
         $this->logger->debug(sprintf('Attempting to verify signature with certificate "%s"', $publicKey->getCertificate()));
         $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));

--- a/src/SurfnetSamlBundle.php
+++ b/src/SurfnetSamlBundle.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle;
 
-use SAML2_Compat_ContainerSingleton;
+use SAML2\Compat\ContainerSingleton;
 use Surfnet\SamlBundle\DependencyInjection\Compiler\SamlAttributeRegistrationCompilerPass;
 use Surfnet\SamlBundle\DependencyInjection\Compiler\SpRepositoryAliasCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,6 +37,6 @@ class SurfnetSamlBundle extends Bundle
     public function boot()
     {
         $bridgeContainer = $this->container->get('surfnet_saml.saml2.bridge_container');
-        SAML2_Compat_ContainerSingleton::setContainer($bridgeContainer);
+        ContainerSingleton::setContainer($bridgeContainer);
     }
 }

--- a/src/Tests/Bootstrap.php
+++ b/src/Tests/Bootstrap.php
@@ -21,4 +21,4 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $container = new \Surfnet\SamlBundle\Tests\TestSaml2Container(
     new \Psr\Log\NullLogger()
 );
-SAML2_Compat_ContainerSingleton::setContainer($container);
+SAML2\Compat\ContainerSingleton::setContainer($container);

--- a/src/Tests/TestSaml2Container.php
+++ b/src/Tests/TestSaml2Container.php
@@ -18,10 +18,10 @@
 
 namespace Surfnet\SamlBundle\Tests;
 
-use SAML2_Compat_AbstractContainer;
+use SAML2\Compat\AbstractContainer;
 use Psr\Log\LoggerInterface;
 
-class TestSaml2Container extends SAML2_Compat_AbstractContainer
+class TestSaml2Container extends AbstractContainer
 {
     /**
      * @var \Psr\Log\LoggerInterface

--- a/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -19,7 +19,7 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use SAML2_Assertion;
+use SAML2\Assertion;
 use stdClass;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
@@ -36,7 +36,7 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
     public function which_attribute_set_is_created_from_a_saml_assertion_is_configurable()
     {
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(self::DUMMY_ATTRIBUTE_SET_CLASS);
-        $attributeSet = ConfigurableAttributeSetFactory::createFrom(new SAML2_Assertion, new AttributeDictionary);
+        $attributeSet = ConfigurableAttributeSetFactory::createFrom(new Assertion, new AttributeDictionary);
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(
             '\Surfnet\SamlBundle\SAML2\Attribute\AttributeSet'
         );

--- a/src/Tests/Unit/SAML2/Attribute/Mock/DummyAttributeSet.php
+++ b/src/Tests/Unit/SAML2/Attribute/Mock/DummyAttributeSet.php
@@ -18,13 +18,13 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute\Mock;
 
-use SAML2_Assertion;
+use SAML2\Assertion;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetFactory;
 
 final class DummyAttributeSet implements AttributeSetFactory
 {
-    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
+    public static function createFrom(Assertion $assertion, AttributeDictionary $attributeDictionary)
     {
         return new self;
     }

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -19,8 +19,8 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2;
 
 use PHPUnit_Framework_TestCase as UnitTest;
-use SAML2_AuthnRequest;
-use SAML2_DOMDocumentFactory;
+use SAML2\AuthnRequest as SAML2AuthnRequest;
+use SAML2\DOMDocumentFactory;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 
 class AuthnRequestTest extends UnitTest
@@ -130,8 +130,8 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
      */
     public function setting_the_subject_generates_valid_xml($nameId, $format)
     {
-        $domDocument = SAML2_DOMDocumentFactory::fromString($this->authRequestNoSubject);
-        $request     = new SAML2_AuthnRequest($domDocument->documentElement);
+        $domDocument = DOMDocumentFactory::fromString($this->authRequestNoSubject);
+        $request     = new SAML2AuthnRequest($domDocument->documentElement);
 
         $authnRequest = AuthnRequest::createNew($request);
         $authnRequest->setSubject($nameId, $format);
@@ -145,8 +145,8 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
      */
     public function the_nameid_and_format_can_be_retrieved_from_the_authnrequest()
     {
-        $domDocument = SAML2_DOMDocumentFactory::fromString($this->authRequestWithSubject);
-        $request     = new SAML2_AuthnRequest($domDocument->documentElement);
+        $domDocument = DOMDocumentFactory::fromString($this->authRequestWithSubject);
+        $request     = new SAML2AuthnRequest($domDocument->documentElement);
 
         $authnRequest = AuthnRequest::createNew($request);
 
@@ -166,8 +166,8 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
      */
     public function is_passive_and_force_authn_can_be_retrieved_from_the_authnrequest($xml, $isPassive, $forceAuthn)
     {
-        $domDocument = SAML2_DOMDocumentFactory::fromString($xml);
-        $request     = new SAML2_AuthnRequest($domDocument->documentElement);
+        $domDocument = DOMDocumentFactory::fromString($xml);
+        $request     = new SAML2AuthnRequest($domDocument->documentElement);
         $authnRequest = AuthnRequest::createNew($request);
 
         $this->assertEquals($isPassive, $authnRequest->isPassive());

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
@@ -19,8 +19,8 @@
 namespace Tests\Unit\SAML2;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use SAML2_AuthnRequest;
-use SAML2_DOMDocumentFactory;
+use SAML2\AuthnRequest as SAML2AuthnRequest;
+use SAML2\DOMDocumentFactory;
 use stdClass;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestQueryString;
 
@@ -257,8 +257,8 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_decoded_saml_request_can_be_acquired_from_a_received_authn_request_query_string()
     {
-        $domDocument          = SAML2_DOMDocumentFactory::fromString($this->authRequestNoSubject);
-        $unsignedAuthnRequest = SAML2_AuthnRequest::fromXML($domDocument->firstChild);
+        $domDocument          = DOMDocumentFactory::fromString($this->authRequestNoSubject);
+        $unsignedAuthnRequest = SAML2AuthnRequest::fromXML($domDocument->firstChild);
 
         $requestAsXml   = $unsignedAuthnRequest->toUnsignedXML()->ownerDocument->saveXML();
         $encodedRequest = base64_encode(gzdeflate($requestAsXml));

--- a/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
@@ -42,7 +42,7 @@ class AssertionAdapterTest extends TestCase
             'urn:oid:0.0.0.0.0.0.0.0.0'
         );
 
-        $assertion = m::mock('\SAML2_Assertion');
+        $assertion = m::mock('\\SAML2\\Assertion');
         $assertion->shouldReceive('getAttributes')->andReturn([$maceAttributeUrn => $maceAttributeValue]);
 
         $dictionary = new AttributeDictionary();
@@ -71,7 +71,7 @@ class AssertionAdapterTest extends TestCase
             $oidAttributeUrn
         );
 
-        $assertion = m::mock('\SAML2_Assertion');
+        $assertion = m::mock('\\SAML2\\Assertion');
         $assertion->shouldReceive('getAttributes')->andReturn([$oidAttributeUrn => $oidAttributeValue]);
 
         $dictionary = new AttributeDictionary();
@@ -84,6 +84,12 @@ class AssertionAdapterTest extends TestCase
         $attributeIsInSet = $attributeSet->contains($attributeExpectedToBeContained);
 
         $this->assertTrue($attributeIsInSet, 'Expected attribute to be part of AttributeSet, but it is not');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        m::close();
     }
 
     /**
@@ -102,7 +108,7 @@ class AssertionAdapterTest extends TestCase
             $oidAttributeUrn
         );
 
-        $assertion = m::mock('\SAML2_Assertion');
+        $assertion = m::mock('\\SAML2\\Assertion');
         $assertion->shouldReceive('getAttributes')->andReturn([$oidAttributeUrn => $oidAttributeValue]);
 
         $attributeExpectedNotToBeContained = new Attribute($existingOidAttributeDefinition, $oidAttributeValue);
@@ -121,7 +127,7 @@ class AssertionAdapterTest extends TestCase
      */
     public function attribute_set_is_empty_if_no_attributes_found()
     {
-        $assertion = m::mock('\SAML2_Assertion');
+        $assertion = m::mock('\\SAML2\\Assertion');
         $assertion->shouldReceive('getAttributes')->andReturn([]);
 
         $dictionary = new AttributeDictionary();
@@ -146,7 +152,7 @@ class AssertionAdapterTest extends TestCase
             $oidAttributeUrn
         );
 
-        $assertion = m::mock('\SAML2_Assertion');
+        $assertion = m::mock('\\SAML2\\Assertion');
         $assertion->shouldReceive('getAttributes')->andReturn([$oidAttributeUrn => $oidAttributeValue]);
 
         $dictionary = new AttributeDictionary();
@@ -174,7 +180,7 @@ class AssertionAdapterTest extends TestCase
             $oidAttributeUrn
         );
 
-        $assertion = m::mock('\SAML2_Assertion');
+        $assertion = m::mock('\\SAML2\\Assertion');
         $assertion->shouldReceive('getAttributes')->andReturn([
             $oidAttributeUrn  => $attributeValue,
             $maceAttributeUrn => $attributeValue

--- a/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
@@ -86,12 +86,6 @@ class AssertionAdapterTest extends TestCase
         $this->assertTrue($attributeIsInSet, 'Expected attribute to be part of AttributeSet, but it is not');
     }
 
-    protected function tearDown()
-    {
-        parent::tearDown();
-        m::close();
-    }
-
     /**
      * @test
      * @group AssertionAdapter

--- a/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
@@ -19,22 +19,22 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Response\Assertion;
 
 use PHPUnit_Framework_TestCase as UnitTest;
-use SAML2_Assertion;
-use SAML2_XML_saml_SubjectConfirmation;
-use SAML2_XML_saml_SubjectConfirmationData;
+use SAML2\Assertion;
+use SAML2\XML\saml\SubjectConfirmation;
+use SAML2\XML\saml\SubjectConfirmationData;
 use Surfnet\SamlBundle\SAML2\Response\Assertion\InResponseTo;
 
 class InResponseToTest extends UnitTest
 {
     /**
-     * @param SAML2_Assertion $assertion
+     * @param Assertion $assertion
      *
      * @test
      * @group saml2-response
      * @group saml2
      * @dataProvider provideAssertionsWithoutInResponseTo
      */
-    public function assertions_without_in_response_to_are_tested_as_if_in_response_to_is_null(SAML2_Assertion $assertion)
+    public function assertions_without_in_response_to_are_tested_as_if_in_response_to_is_null(Assertion $assertion)
     {
         $this->assertTrue(InResponseTo::assertEquals($assertion, null));
         $this->assertFalse(InResponseTo::assertEquals($assertion, 'some not-null-value'));
@@ -47,9 +47,9 @@ class InResponseToTest extends UnitTest
      */
     public function in_reponse_to_equality_is_strictly_checked()
     {
-        $assertion                   = new SAML2_Assertion();
-        $subjectConfirmationWithData = new SAML2_XML_saml_SubjectConfirmation();
-        $subjectConfirmationData     = new SAML2_XML_saml_SubjectConfirmationData();
+        $assertion                   = new Assertion();
+        $subjectConfirmationWithData = new SubjectConfirmation();
+        $subjectConfirmationData     = new SubjectConfirmationData();
         $subjectConfirmationData->InResponseTo = '1';
         $subjectConfirmationWithData->SubjectConfirmationData = $subjectConfirmationData;
         $assertion->setSubjectConfirmation([$subjectConfirmationWithData]);
@@ -63,15 +63,15 @@ class InResponseToTest extends UnitTest
      */
     public function provideAssertionsWithoutInResponseTo()
     {
-        $assertionWithoutSubjectConfirmation = new SAML2_Assertion();
+        $assertionWithoutSubjectConfirmation = new Assertion();
 
-        $assertionWithoutSubjectConfirmationData = new SAML2_Assertion();
-        $subjectConfirmation = new SAML2_XML_saml_SubjectConfirmation();
+        $assertionWithoutSubjectConfirmationData = new Assertion();
+        $subjectConfirmation = new SubjectConfirmation();
         $assertionWithoutSubjectConfirmationData->setSubjectConfirmation([$subjectConfirmation]);
 
-        $assertionWithEmptyInResponseTo = new SAML2_Assertion();
-        $subjectConfirmationWithData = new SAML2_XML_saml_SubjectConfirmation();
-        $subjectConfirmationWithData->SubjectConfirmationData = new SAML2_XML_saml_SubjectConfirmationData();
+        $assertionWithEmptyInResponseTo = new Assertion();
+        $subjectConfirmationWithData = new SubjectConfirmation();
+        $subjectConfirmationWithData->SubjectConfirmationData = new SubjectConfirmationData();
         $assertionWithEmptyInResponseTo->setSubjectConfirmation([$subjectConfirmationWithData]);
 
         return [


### PR DESCRIPTION
This PR will update the SAML2 library and the XMLSecLibs composer dependencies to the latest and greatest version. The code was scanned for usage of no longer supported library features. These occurrences have been updated. Most notable changes are:

* SAML2 library now uses PSR namespaces. All references to the old ZF1 style 'namespaces' have been updated.
* XMLSecLibsKey usages are updated to use the correct namespace.

More backgrounds can be found in the issue: #71 