### PR TITLE
Fix faulty NameId 'value' and 'Format' retrieval

### DIFF
--- a/src/SAML2/ReceivedAuthnRequest.php
+++ b/src/SAML2/ReceivedAuthnRequest.php
@@ -97,11 +97,11 @@ final class ReceivedAuthnRequest
     public function getNameId()
     {
         $nameId = $this->request->getNameId();
-        if (!is_array($nameId) || !array_key_exists('Value', $nameId)) {
+        if (!$nameId) {
             return null;
         }
 
-        return $nameId['Value'];
+        return $nameId->value;
     }
 
     /**
@@ -110,11 +110,11 @@ final class ReceivedAuthnRequest
     public function getNameIdFormat()
     {
         $nameId = $this->request->getNameId();
-        if (!is_array($nameId) || !array_key_exists('Format', $nameId)) {
+        if (!$nameId) {
             return null;
         }
 
-        return $nameId['Format'];
+        return $nameId->Format;
     }
 
     /**

--- a/src/SAML2/Response/AssertionAdapter.php
+++ b/src/SAML2/Response/AssertionAdapter.php
@@ -53,8 +53,8 @@ class AssertionAdapter
     public function getNameID()
     {
         $data = $this->assertion->getNameId();
-        if (is_array($data) && array_key_exists('Value', $data)) {
-            return $data['Value'];
+        if ($data) {
+            return $data->value;
         }
 
         return null;


### PR DESCRIPTION
The NameId is no longer represented by an array. As of version 3 of the
SAML2 library this value is a public property of the NameId object.