### PR TITLE
Allow empty NameID in authn request

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -166,6 +166,10 @@ class AuthnRequest
     {
         $nameId = $this->request->getNameId();
 
+        if (!isset($nameId->value)) {
+            return;
+        }
+
         return $nameId->value;
     }
 
@@ -175,6 +179,10 @@ class AuthnRequest
     public function getNameIdFormat()
     {
         $nameId = $this->request->getNameId();
+
+        if (!isset($nameId->Format)) {
+            return;
+        }
 
         return $nameId->Format;
     }


### PR DESCRIPTION
Commit 90f7a33 incorrectly assumed there is always a NameID, which is
not the case. This commit restores the original behaviour where null
is returned when there is no NameID.