### PR TITLE
Throw specific exceptions on signature errors

### DIFF
--- a/src/Http/Exception/SignatureValidationFailedException.php
+++ b/src/Http/Exception/SignatureValidationFailedException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2014 SURFnet bv
+ * Copyright 2018 SURFnet bv
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,6 @@ namespace Surfnet\SamlBundle\Http\Exception;
 use Surfnet\SamlBundle\Exception\Exception;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
-class UnknownServiceProviderException extends BadRequestHttpException implements Exception
+class SignatureValidationFailedException extends BadRequestHttpException implements Exception
 {
-    /**
-     * @var string
-     */
-    private $entityId;
-
-    public function __construct($entityId)
-    {
-        $this->entityId = $entityId;
-
-        parent::__construct(sprintf(
-            'AuthnRequest received from ServiceProvider with an unknown EntityId: "%s"',
-            $entityId
-        ));
-    }
-
-    public function getEntityId()
-    {
-        return $this->entityId;
-    }
 }

--- a/src/Http/Exception/UnsignedRequestException.php
+++ b/src/Http/Exception/UnsignedRequestException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2014 SURFnet bv
+ * Copyright 2018 SURFnet bv
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,6 @@ namespace Surfnet\SamlBundle\Http\Exception;
 use Surfnet\SamlBundle\Exception\Exception;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
-class UnknownServiceProviderException extends BadRequestHttpException implements Exception
+class UnsignedRequestException extends BadRequestHttpException implements Exception
 {
-    /**
-     * @var string
-     */
-    private $entityId;
-
-    public function __construct($entityId)
-    {
-        $this->entityId = $entityId;
-
-        parent::__construct(sprintf(
-            'AuthnRequest received from ServiceProvider with an unknown EntityId: "%s"',
-            $entityId
-        ));
-    }
-
-    public function getEntityId()
-    {
-        return $this->entityId;
-    }
 }

--- a/src/Http/Exception/UnsupportedSignatureException.php
+++ b/src/Http/Exception/UnsupportedSignatureException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2014 SURFnet bv
+ * Copyright 2018 SURFnet bv
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,22 @@ namespace Surfnet\SamlBundle\Http\Exception;
 use Surfnet\SamlBundle\Exception\Exception;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
-class UnknownServiceProviderException extends BadRequestHttpException implements Exception
+class UnsupportedSignatureException extends BadRequestHttpException implements Exception
 {
     /**
      * @var string
      */
-    private $entityId;
+    private $signatureAlgorithm;
 
-    public function __construct($entityId)
+    public function __construct($signatureAlgorithm)
     {
-        $this->entityId = $entityId;
+        $this->signatureAlgorithm = $signatureAlgorithm;
 
-        parent::__construct(sprintf(
-            'AuthnRequest received from ServiceProvider with an unknown EntityId: "%s"',
-            $entityId
-        ));
-    }
-
-    public function getEntityId()
-    {
-        return $this->entityId;
+        parent::__construct(
+            sprintf(
+                'The SAMLRequest has been signed, but the signature format "%s" is not supported',
+                $signatureAlgorithm
+            )
+        );
     }
 }

--- a/src/Http/PostBinding.php
+++ b/src/Http/PostBinding.php
@@ -34,6 +34,7 @@ use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Entity\ServiceProviderRepository;
 use Surfnet\SamlBundle\Http\Exception\AuthnFailedSamlResponseException;
 use Surfnet\SamlBundle\Http\Exception\NoAuthnContextSamlResponseException;
+use Surfnet\SamlBundle\Http\Exception\SignatureValidationFailedException;
 use Surfnet\SamlBundle\Http\Exception\UnknownServiceProviderException;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest;
@@ -169,8 +170,8 @@ class PostBinding implements HttpBinding
 
         // Note: verifyIsSignedBy throws an Exception when the signature does not match.
         if (!$this->signatureVerifier->verifyIsSignedBy($receivedRequest, $serviceProvider)) {
-            throw new BadRequestHttpException(
-                'The SAMLRequest has been signed, but the signature format is not supported'
+            throw new SignatureValidationFailedException(
+                'Validation of the signature in the AuthnRequest failed'
             );
         }
 

--- a/src/Http/ReceivedAuthnRequestQueryString.php
+++ b/src/Http/ReceivedAuthnRequestQueryString.php
@@ -263,7 +263,7 @@ final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
      */
     public function getSignatureAlgorithm()
     {
-        return $this->signatureAlgorithm;
+        return urldecode($this->signatureAlgorithm);
     }
 
     /**

--- a/src/Signing/SignatureVerifier.php
+++ b/src/Signing/SignatureVerifier.php
@@ -24,6 +24,7 @@ use SAML2\Certificate\Key;
 use SAML2\Certificate\KeyLoader as KeyLoader;
 use SAML2\Certificate\X509;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Http\ReceivedAuthnRequestQueryString;
 use Surfnet\SamlBundle\Http\SignatureVerifiable;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 
@@ -74,6 +75,15 @@ class SignatureVerifier
         $this->logger->debug('Signature could not be verified with any of the found X509 keys.');
 
         return false;
+    }
+
+    /**
+     * @param ReceivedAuthnRequestQueryString $request
+     * @return bool
+     */
+    public function verifySignatureAlgorithmSupported(ReceivedAuthnRequestQueryString $request)
+    {
+        return $request->getSignatureAlgorithm() === XMLSecurityKey::RSA_SHA256;
     }
 
     /**


### PR DESCRIPTION
Instead of throwing bad request HTTP exceptions, new exceptions have
been added for the following cases:

 - no signature found in request or no sigalg specified:
   -> UnsignedRequestException

 - the request was signed with an unsupported algorithm (not
   SHA_RSA256)
   -> UnsupportedSignatureException

 - validation of the signature failed
   -> SignatureValidationFailedException

All exceptions extend BadRequestHttpException so this change should be
backwards compatible.