### PR TITLE
Add Symfony 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
     - ~/.composer
 
 before_script:
-  - phpenv config-add .travis.php.ini
+  - phpenv config-add travis.php.ini
   - composer self-update
   - composer install --prefer-dist
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,8 @@
 services:
+    # Remove the public: true default once DI is implemented throughout the StepUp applications. See Pivotal #138225085
+    _defaults:
+        public: true
+
     surfnet_saml.saml.attribute_dictionary:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary
         arguments:

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -6,3 +6,4 @@
 ;
 
 date.timezone = "Europe/Amsterdam"
+memory_limit = 2048M


### PR DESCRIPTION
Fixing all deprecation warnings mentioning the usage of private services
, by implementing dependency injection on all services, is one bridge to
far to address in this PR.

This will be rolled back in Pivotal story #138225085!