### PR TITLE
Remove the unused SURFconextID attribute from dict

### DIFF
--- a/src/Resources/config/saml_attributes.yml
+++ b/src/Resources/config/saml_attributes.yml
@@ -197,15 +197,6 @@ services:
         tags:
             - { name: 'saml.attribute' }
 
-    saml.attribute.surfconext.id:
-        class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
-        arguments:
-            - surfconextId
-            - ~
-            - 'urn:oid:1.3.6.1.4.1.1076.20.40.40.1'
-        tags:
-            - { name: 'saml.attribute' }
-
     saml.attribute.eduPersonTargetedID:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
         arguments:


### PR DESCRIPTION
The attribute is no longer released from EB, and according to the
product owners it is not used by any SP.

Removing it thoughout the OpenConext suite seems a good idea.

https://www.pivotaltracker.com/story/show/160788232