### PR TITLE
Fix the failing Travis builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /cache.properties
 /vendor/
 .idea
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,15 @@ language: php
 
 php:
   - 5.6
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 matrix:
   allow_failures:
-    - php: 7.0
     - php: 7.1
+    - php: 7.2
+    - php: 7.3
 
 env:
   global:

--- a/build.xml
+++ b/build.xml
@@ -46,9 +46,7 @@
 
     <target name="php-security-checker" description="Check your composer dependencies for insecure components">
         <exec executable="vendor/bin/security-checker" failonerror="false">
-            <arg value="security:check"/>
-            <arg value="--verbose"/>
-            <arg value="composer.lock"/>
+            <arg line="security:check" />
         </exec>
     </target>
 

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,15 @@
         "robrichards/xmlseclibs": "^3.0"
     },
     "require-dev": {
-        "ibuildings/qa-tools": "~1.1",
+        "mockery/mockery": "~1.0",
+        "phpmd/phpmd": "^2.6",
+        "phpunit/phpunit": "^5.7",
+        "sebastian/exporter": "~2.0",
+        "sebastian/phpcpd": "^2.0",
+        "squizlabs/php_codesniffer": "^3.0",
         "mockery/mockery": "~0.9",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "sensiolabs/security-checker": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "robrichards/xmlseclibs": "^3.0"
     },
     "require-dev": {
-        "mockery/mockery": "~1.0",
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "^5.7",
         "sebastian/exporter": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.6,<8.0-dev",
         "ext-openssl": "*",
-        "simplesamlphp/saml2": "^3.0",
+        "simplesamlphp/saml2": "3.2.*",
         "symfony/dependency-injection": ">=2.7,<4",
         "symfony/framework-bundle": ">=2.7,<4",
         "robrichards/xmlseclibs": "^3.0"

--- a/src/Metadata/MetadataConfiguration.php
+++ b/src/Metadata/MetadataConfiguration.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\SamlBundle\Metadata;
 
-
 class MetadataConfiguration
 {
     /**


### PR DESCRIPTION
Several problems needed some attention:

1. The Ibuildings QA tools are no longer maintained. So installed the required testing tools manually in the dev section of the composer.json;
2. Updated the task runner (ant) in order to work correctly with the newer versions of the tools;
3. A downgrade (version pin to 3.2.x) of the SAML2 lib was required to ensure PHP 5.6 support;
4. And finally, support for the maintained PHP versions have been enabled in the Travis configuration. So versions 5.6, 7.1, 7.2 and 7.3 are tested. Where, yes I know, 5.6 is a no longer maintained version.