### PR TITLE
Add support for Symfony 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,18 @@
 
 language: php
 
-php:
-  - 5.6
-  - 7.1
-  - 7.2
-  - 7.3
-
 matrix:
-  allow_failures:
+  include:
+    - php: 5.6
+      env: SYMFONY_VERSION="3.4.*"
     - php: 7.1
+      env: SYMFONY_VERSION="3.4.*"
     - php: 7.2
+      env: SYMFONY_VERSION="3.4.*"
+    - php: 7.2
+      env: SYMFONY_VERSION="4.3.*"
     - php: 7.3
+      env: SYMFONY_VERSION="4.3.*"
 
 env:
   global:
@@ -30,7 +31,10 @@ cache:
 before_script:
   - phpenv config-add travis.php.ini
   - composer self-update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - composer install --prefer-dist
+  - sudo apt-get -qq update
+  - sudo apt-get install ant
 
 script:
   - ant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.9
+**New feature**
+* Provide minimal Symfony 4 support #89 
+
 # 4.1.8
 This is a security release that will harden the application against CVE 2019-3465
  * Force upgrade of xmlseclibs to version 3.0.4 #90

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ For Syfony 3.4 support use version 4.1.1 or greater.
   }
   ```
 
+For sf 4.3 you should configure the templating engine:
+
+```yaml
+framework:
+    templating:
+        engines:
+        - twig
+```      
+
 ## Configuration
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Developed as part of the [SURFnet StepUp Gateway][2]
   composer require surfnet/stepup-saml-bundle
   ```
 
-For Syfony 3.4 support use version 4.1.1 or greater.
+For Symfony 3.4 support use version 4.1.1 or greater.
 
 * Add the bundle to your kernel in `app/AppKernel.php`
   ```php
@@ -26,13 +26,21 @@ For Syfony 3.4 support use version 4.1.1 or greater.
   }
   ```
 
-For sf 4.3 you should configure the templating engine:
+For use of this bundle in Symfony 4.3
+ 
+1. Require the bundle in the composer.json (version 4.1.9 or higher)
+2. Enable the bundle in `config/bundles.php` add to the return statement: `Surfnet\SamlBundle\SurfnetSamlBundle::class => ['all' => true],`
+3. Specify the bundle configuration in `config/packages/surfnet_saml.yml`, consult the configuration section below for available options.
+ 
+And, on top of that you should explicitly configure the Twig templating engine:
+
+In `config/packages/framework.yaml` add:
 
 ```yaml
 framework:
     templating:
         engines:
-        - twig
+            - twig
 ```      
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ class MetadataController extends Controller
 ## Release strategy
 
 ### CHANGELOG.md
-Please read: https://github.com/OpenConext/Stepup-Deploy/wiki/Release-Management fro more information on the release strategy used in Stepup projects.
+Please read: https://github.com/OpenConext/Stepup-Deploy/wiki/Release-Management for more information on the release strategy used in Stepup projects.
 
 ### UPGRADING.md
 When introducing backwards compatible breaking changes in the bundle. Please update the UPGRADING.md file to instruct

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,14 @@
+# UPGRADE FROM X to 4.1.9
+
+When using this bundle with Symfony 4.3 you should configure the templating engine:
+
+```yaml
+framework:
+    templating:
+        engines:
+            - twig
+```        
+
 # UPGRADE FROM 3.X to 4.X
 This release makes error reporting more specific. This release changed the API of the
 `ReceivedAuthnRequestQueryString::getSignatureAlgorithm` method, returning the signature algorithm url decoded. Any

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "ext-openssl": "*",
         "robrichards/xmlseclibs": "^3.0.4",
         "simplesamlphp/saml2": "3.2.*",
-        "symfony/dependency-injection": "^3.4 || ^4.3",
-        "symfony/framework-bundle": "^3.4 || ^4.3",
+        "symfony/dependency-injection": "^3.4.26 || ^4.3",
+        "symfony/framework-bundle": "^3.4.26 || ^4.3",
         "symfony/templating": "^3.4 || ^4.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "surfnet/stepup-saml-bundle",
     "type": "symfony-bundle",
-    "description": "A Symfony2 bundle that integrates the simplesamlphp\\saml2 library with Symfony",
+    "description": "A Symfony 3 (with SF 4 support) bundle that integrates the simplesamlphp\\saml2 library with Symfony.",
     "keywords": ["surfnet", "StepUp", "simplesamlphp", "SAML", "SAML2"],
     "license": "Apache-2.0",
     "minimum-stability": "stable",
@@ -9,8 +9,8 @@
         "php": ">=5.6,<8.0-dev",
         "ext-openssl": "*",
         "simplesamlphp/saml2": "3.2.*",
-        "symfony/dependency-injection": ">=2.7,<4",
-        "symfony/framework-bundle": ">=2.7,<4",
+        "symfony/dependency-injection": "~3.4 || ~4.3",
+        "symfony/framework-bundle": "~3.4 || ~4.3",
         "robrichards/xmlseclibs": "^3.0.4"
     },
     "require-dev": {
@@ -21,7 +21,11 @@
         "squizlabs/php_codesniffer": "^3.0",
         "mockery/mockery": "~0.9",
         "psr/log": "~1.0",
-        "sensiolabs/security-checker": "^5.0"
+        "sensiolabs/security-checker": "^5.0",
+        "symfony/phpunit-bridge": "^4.3"
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,11 @@
     "require": {
         "php": ">=5.6,<8.0-dev",
         "ext-openssl": "*",
+        "robrichards/xmlseclibs": "^3.0.4",
         "simplesamlphp/saml2": "3.2.*",
-        "symfony/dependency-injection": "~3.4 || ~4.3",
-        "symfony/framework-bundle": "~3.4 || ~4.3",
-        "robrichards/xmlseclibs": "^3.0.4"
+        "symfony/dependency-injection": "^3.4 || ^4.3",
+        "symfony/framework-bundle": "^3.4 || ^4.3",
+        "symfony/templating": "^3.4 || ^4.3"
     },
     "require-dev": {
         "phpmd/phpmd": "^2.6",

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+  "bundles": {
+    "Surfnet\\SamlBundle\\SurfnetSamlBundle": ["all"]
+  },
+  "aliases": ["stepup-saml"]
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,6 +27,7 @@
         </whitelist>
     </filter>
     <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
+        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener"/>
     </listeners>
 </phpunit>

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -7,13 +7,13 @@ services:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary
         arguments:
             - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
-        deprecated: ~
+
     Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary:
         alias: surfnet_saml.saml.attribute_dictionary
 
     surfnet_saml.configuration.metadata:
         class: Surfnet\SamlBundle\Metadata\MetadataConfiguration
-        deprecated: ~
+
     Surfnet\SamlBundle\Metadata\MetadataConfiguration:
         alias: surfnet_saml.configuration.metadata
 
@@ -25,7 +25,7 @@ services:
             - '@request_stack'
             - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
             - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
-        deprecated: ~
+
     Surfnet\SamlBundle\Entity\HostedEntities:
         alias: surfnet_saml.configuration.hosted_entities
         public: false
@@ -33,14 +33,14 @@ services:
     surfnet_saml.hosted.service_provider:
         class:   Surfnet\SamlBundle\Entity\ServiceProvider
         factory: ['@surfnet_saml.configuration.hosted_entities', getServiceProvider]
-        deprecated: ~
+
     Surfnet\SamlBundle\Entity\ServiceProvider:
         alias: surfnet_saml.hosted.service_provider
 
     surfnet_saml.hosted.identity_provider:
         class:   Surfnet\SamlBundle\Entity\IdentityProvider
         factory: ['@surfnet_saml.configuration.hosted_entities', getIdentityProvider]
-        deprecated: ~
+
     Surfnet\SamlBundle\Entity\IdentityProvider:
         alias: surfnet_saml.hosted.identity_provider
 
@@ -49,7 +49,7 @@ services:
         arguments:
             - '@surfnet_saml.http.redirect_binding'
             - '@surfnet_saml.http.post_binding'
-        deprecated: ~
+
     Surfnet\SamlBundle\Http\HttpBindingFactory:
         alias: surfnet_saml.http.binding_factory
 
@@ -59,7 +59,7 @@ services:
             - '@logger'
             - '@surfnet_saml.signing.signature_verifier'
             - '@?surfnet_saml.entity.entity_repository'
-        deprecated: ~
+
     Surfnet\SamlBundle\Http\RedirectBinding:
         alias: surfnet_saml.http.redirect_binding
 
@@ -70,7 +70,7 @@ services:
             - '@logger'
             - '@surfnet_saml.signing.signature_verifier'
             - '@?surfnet_saml.entity.entity_repository'
-        deprecated: ~
+
     Surfnet\SamlBundle\Http\PostBinding:
         alias: surfnet_saml.http.post_binding
 
@@ -81,7 +81,7 @@ services:
             - '@router'
             - '@surfnet_saml.signing_service'
             - '@surfnet_saml.configuration.metadata'
-        deprecated: ~
+
     Surfnet\SamlBundle\Metadata\MetadataFactory:
         alias: surfnet_saml.metadata_factory
 
@@ -90,7 +90,7 @@ services:
         arguments:
             - '@surfnet_saml.saml2.keyloader'
             - '@surfnet_saml.saml2.privatekeyloader'
-        deprecated: ~
+
     Surfnet\SamlBundle\Service\SigningService:
         alias: surfnet_saml.signing_service
 
@@ -99,7 +99,7 @@ services:
         arguments:
             - '@surfnet_saml.saml2.keyloader'
             - '@logger'
-        deprecated: ~
+
     Surfnet\SamlBundle\Signing\SignatureVerifier:
         alias: surfnet_saml.signing.signature_verifier
 
@@ -107,14 +107,14 @@ services:
         class: Surfnet\SamlBundle\SAML2\BridgeContainer
         arguments:
             - '@logger'
-        deprecated: ~
+
     Surfnet\SamlBundle\SAML2\BridgeContainer:
         alias: surfnet_saml.saml2.bridge_container
 
     surfnet_saml.saml2.keyloader:
         public: false
         class: SAML2\Certificate\KeyLoader
-        deprecated: ~
+
     SAML2\Certificate\KeyLoader:
         public: false
         alias: surfnet_saml.saml2.keyloader
@@ -122,7 +122,7 @@ services:
     surfnet_saml.saml2.privatekeyloader:
         public: false
         class: SAML2\Certificate\PrivateKeyLoader
-        deprecated: ~
+
     SAML2\Certificate\PrivateKeyLoader:
         public: false
         alias: surfnet_saml.saml2.privatekeyloader
@@ -132,7 +132,7 @@ services:
         class: SAML2\Response\Processor
         arguments:
             - '@logger'
-        deprecated: ~
+
     SAML2\Response\Processor:
         public: false
         alias: surfnet_saml.saml2.response_processor
@@ -141,6 +141,6 @@ services:
         class: Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger
         arguments:
             - '@logger'
-        deprecated: ~
+
     Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger:
         alias: surfnet_saml.logger

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -7,9 +7,15 @@ services:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary
         arguments:
             - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
+        deprecated: ~
+    Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary:
+        alias: surfnet_saml.saml.attribute_dictionary
 
     surfnet_saml.configuration.metadata:
         class: Surfnet\SamlBundle\Metadata\MetadataConfiguration
+        deprecated: ~
+    Surfnet\SamlBundle\Metadata\MetadataConfiguration:
+        alias: surfnet_saml.configuration.metadata
 
     surfnet_saml.configuration.hosted_entities:
         public: false
@@ -19,20 +25,33 @@ services:
             - '@request_stack'
             - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
             - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
+        deprecated: ~
+    Surfnet\SamlBundle\Entity\HostedEntities:
+        alias: surfnet_saml.configuration.hosted_entities
+        public: false
 
     surfnet_saml.hosted.service_provider:
         class:   Surfnet\SamlBundle\Entity\ServiceProvider
         factory: ['@surfnet_saml.configuration.hosted_entities', getServiceProvider]
+        deprecated: ~
+    Surfnet\SamlBundle\Entity\ServiceProvider:
+        alias: surfnet_saml.hosted.service_provider
 
     surfnet_saml.hosted.identity_provider:
         class:   Surfnet\SamlBundle\Entity\IdentityProvider
         factory: ['@surfnet_saml.configuration.hosted_entities', getIdentityProvider]
+        deprecated: ~
+    Surfnet\SamlBundle\Entity\IdentityProvider:
+        alias: surfnet_saml.hosted.identity_provider
 
     surfnet_saml.http.binding_factory:
         class: Surfnet\SamlBundle\Http\HttpBindingFactory
         arguments:
             - '@surfnet_saml.http.redirect_binding'
             - '@surfnet_saml.http.post_binding'
+        deprecated: ~
+    Surfnet\SamlBundle\Http\HttpBindingFactory:
+        alias: surfnet_saml.http.binding_factory
 
     surfnet_saml.http.redirect_binding:
         class: Surfnet\SamlBundle\Http\RedirectBinding
@@ -40,6 +59,9 @@ services:
             - '@logger'
             - '@surfnet_saml.signing.signature_verifier'
             - '@?surfnet_saml.entity.entity_repository'
+        deprecated: ~
+    Surfnet\SamlBundle\Http\RedirectBinding:
+        alias: surfnet_saml.http.redirect_binding
 
     surfnet_saml.http.post_binding:
         class: Surfnet\SamlBundle\Http\PostBinding
@@ -48,6 +70,9 @@ services:
             - '@logger'
             - '@surfnet_saml.signing.signature_verifier'
             - '@?surfnet_saml.entity.entity_repository'
+        deprecated: ~
+    Surfnet\SamlBundle\Http\PostBinding:
+        alias: surfnet_saml.http.post_binding
 
     surfnet_saml.metadata_factory:
         class: Surfnet\SamlBundle\Metadata\MetadataFactory
@@ -56,39 +81,66 @@ services:
             - '@router'
             - '@surfnet_saml.signing_service'
             - '@surfnet_saml.configuration.metadata'
+        deprecated: ~
+    Surfnet\SamlBundle\Metadata\MetadataFactory:
+        alias: surfnet_saml.metadata_factory
 
     surfnet_saml.signing_service:
         class: Surfnet\SamlBundle\Service\SigningService
         arguments:
             - '@surfnet_saml.saml2.keyloader'
             - '@surfnet_saml.saml2.privatekeyloader'
+        deprecated: ~
+    Surfnet\SamlBundle\Service\SigningService:
+        alias: surfnet_saml.signing_service
 
     surfnet_saml.signing.signature_verifier:
         class: Surfnet\SamlBundle\Signing\SignatureVerifier
         arguments:
             - '@surfnet_saml.saml2.keyloader'
             - '@logger'
+        deprecated: ~
+    Surfnet\SamlBundle\Signing\SignatureVerifier:
+        alias: surfnet_saml.signing.signature_verifier
 
     surfnet_saml.saml2.bridge_container:
         class: Surfnet\SamlBundle\SAML2\BridgeContainer
         arguments:
             - '@logger'
+        deprecated: ~
+    Surfnet\SamlBundle\SAML2\BridgeContainer:
+        alias: surfnet_saml.saml2.bridge_container
 
     surfnet_saml.saml2.keyloader:
         public: false
         class: SAML2\Certificate\KeyLoader
+        deprecated: ~
+    SAML2\Certificate\KeyLoader:
+        public: false
+        alias: surfnet_saml.saml2.keyloader
 
     surfnet_saml.saml2.privatekeyloader:
         public: false
         class: SAML2\Certificate\PrivateKeyLoader
+        deprecated: ~
+    SAML2\Certificate\PrivateKeyLoader:
+        public: false
+        alias: surfnet_saml.saml2.privatekeyloader
 
     surfnet_saml.saml2.response_processor:
         public: false
         class: SAML2\Response\Processor
         arguments:
             - '@logger'
+        deprecated: ~
+    SAML2\Response\Processor:
+        public: false
+        alias: surfnet_saml.saml2.response_processor
 
     surfnet_saml.logger:
         class: Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger
         arguments:
             - '@logger'
+        deprecated: ~
+    Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger:
+        alias: surfnet_saml.logger


### PR DESCRIPTION
- Add symfony/phpunit-bridge to make sure we are not using deprecated
dependencies
- Add extra CI run for SF 4 with php 7.2

https://www.pivotaltracker.com/story/show/167697164