### PR TITLE
Force upgrade of xmlseclibs to version 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 4.1.8
+This is a security release that will harden the application against CVE 2019-3465
+ * Force upgrade of xmlseclibs to version 3.0.4 #90
+ * Enable ant on Travis builds #91
+
+# 4.1.7
+Remove deprecation notices
+ * Alias will also give warnings, service names should be fixed completely in the future.
+  
+# 4.1.6
+No release notes specified for this release
+
 # 4.1.5
 **New feature**
 * Add new attribute eckId #88

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "simplesamlphp/saml2": "3.2.*",
         "symfony/dependency-injection": ">=2.7,<4",
         "symfony/framework-bundle": ">=2.7,<4",
-        "robrichards/xmlseclibs": "^3.0"
+        "robrichards/xmlseclibs": "^3.0.4"
     },
     "require-dev": {
         "phpmd/phpmd": "^2.6",


### PR DESCRIPTION
This to harden against CVE 2019-3465, this version bump effectively updates robrichards/xmlseclibs to version 3.0.4 by adding a caret version constraint on that version. This still allows the installation of newer versions but smaller than 4.0.

This PR is targetted at version: 4.1 only