### PR TITLE
Enable ant on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,8 @@ branches:
   only:
     - master
     - develop
+
+addons:
+  apt:
+    packages:
+      - ant


### PR DESCRIPTION
Ant is no longer installed by default on the Travis platform. An explicit installtion instruction was added to achieve installation.