### PR TITLE
Support multiple remote identity providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,25 @@ surfnet_saml:
               assertion_consumer_service_url: "%surfnet_saml_remote_sp_acs%"            
 ```
 
-The hosted configuration lists the configuration for the services (SP, IdP or both) that your application offers. SP and IdP
+The `hosted:` configuration lists the configuration for the services (SP, IdP or both) that your application offers. SP and IdP
  functionality can be turned off and on individually through the repective `enabled` flags.
-The remote configuration lists, if enabled, the configuration for a remote IdP to connect to.
+
+The `remote:` configuration lists, if enabled, the configuration for one or more remote service providers and identity providers to connect to.
+If your application authenticates with a single identity provider, you can use the `identity_provider:` option as shown above. The identity
+provider can be accessed runtime using the `@surfnet_saml.remote.idp` service.
+
+If your application authenticates with more than one identity providers, you can omit the `identity_provider:` key from configuration and list all
+identity providers under `identity_providers:`. The identity providers can be accessed by using the `@surfnet_saml.remote.identity_providers` service.
+```yaml
+    remote:
+        identity_providers:
+            -  enabled: true
+               entity_id: %surfnet_saml_remote_idp_entity_id%
+               sso_url: %surfnet_saml_remote_idp_sso_url%
+               certificate: %surfnet_saml_remote_idp_certificate%
+
+```
+
 The inlined certificate in the last line can be replaced with `certificate_file` containing a filesystem path to
 a file which contains said certificate.
 It is recommended to use parameters as listed above. The various `publickey` and `privatekey` variables are the

--- a/src/Entity/IdentityProviderRepository.php
+++ b/src/Entity/IdentityProviderRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Entity;
+
+interface IdentityProviderRepository
+{
+    /**
+     * @param string $entityId
+     * @return IdentityProvider
+     */
+    public function getIdentityProvider($entityId);
+
+    /**
+     * @param string $entityId
+     * @return bool
+     */
+    public function hasIdentityProvider($entityId);
+}

--- a/src/Entity/ImmutableCollection/IdentityProviders.php
+++ b/src/Entity/ImmutableCollection/IdentityProviders.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Entity\ImmutableCollection;
+
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+
+/**
+ * Collection of identity providers
+ *
+ * Protects the integrity and provides low level logic functions.
+ */
+final class IdentityProviders
+{
+    private $identityProviders;
+
+    /**
+     *
+     * @param IdentityProvider[] $identityProviders
+     */
+    public function __construct(array $identityProviders)
+    {
+        $this->identityProviders = array_values($identityProviders);
+    }
+
+    public function hasByEntityId($entityId)
+    {
+        return $this->findByEntityId($entityId) !== null;
+    }
+
+    public function findByEntityId($entityId)
+    {
+        return $this->find(function (IdentityProvider $provider) use ($entityId) {
+            return $provider->getEntityId() === $entityId;
+        });
+    }
+
+    private function find(callable $callback)
+    {
+        foreach ($this->identityProviders as $provider) {
+            if ($callback($provider)) {
+                return $provider;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Entity/StaticIdentityProviderRepository.php
+++ b/src/Entity/StaticIdentityProviderRepository.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Entity;
+
+use Surfnet\SamlBundle\Entity\ImmutableCollection\IdentityProviders;
+use Surfnet\SamlBundle\Exception\NotFound;
+
+final class StaticIdentityProviderRepository implements IdentityProviderRepository
+{
+    private $identityProviders;
+
+    /**
+     *
+     * @param IdentityProvider[] $identityProviders
+     */
+    public function __construct(array $identityProviders)
+    {
+        $this->identityProviders = new IdentityProviders($identityProviders);
+    }
+
+    /**
+     * @param string $entityId
+     * @return IdentityProvider
+     * @throws NotFound
+     */
+    public function getIdentityProvider($entityId)
+    {
+        $identityProvider = $this->identityProviders->findByEntityId($entityId);
+        if ($identityProvider) {
+            return $identityProvider;
+        }
+
+        throw NotFound::identityProvider($entityId);
+    }
+
+    /**
+     * @param string $entityId
+     * @return bool
+     */
+    public function hasIdentityProvider($entityId)
+    {
+        return $this->identityProviders->hasByEntityId($entityId);
+    }
+}


### PR DESCRIPTION
This change allows configuring multiple remote identity providers
instead of a single remote identity provider.

This change is fully backwards compatible:

 - if a single identity provider is configured, the identity provider
   is still availble using the `surfnet_saml.remote.idp` service ID

 - if multiple identity providers are configured, a new repository is
   injected into the service container in identical fashion to how
   this works for service providers

The README is updated with instructions for both use-cases.

Ideally we'd ship this change with some tests, but this requires
writing an integration test for the bundle: the bulk of the change is
in how configuration is parsed. We don't yet have that kind of tests.

Resolves https://github.com/OpenConext/Stepup-saml-bundle/issues/81