### PR TITLE
Convert debugged SAML message to string

### DIFF
--- a/src/SAML2/BridgeContainer.php
+++ b/src/SAML2/BridgeContainer.php
@@ -56,6 +56,10 @@ class BridgeContainer extends AbstractContainer
 
     public function debugMessage($message, $type)
     {
+        if ($message instanceof \DOMElement) {
+            $message = $message->ownerDocument->saveXML($message);
+        }
+
         $this->logger->debug($message, ['type' => $type]);
     }
 


### PR DESCRIPTION
There are a problem when [BridgeContainer::debugMessage](https://github.com/OpenConext/Stepup-saml-bundle/blob/5c5566f65131582567cbffd1b4520fc8b0f25396/src/SAML2/BridgeContainer.php#L59) is called.

```
    public function debugMessage($message, $type)
    {
        $this->logger->debug($message, ['type' => $type]);
    }
```

When `$message` is a DOMElement I get an `Object of class DOMElement could not be converted to string` error.

According with [SAML::AbstractContainer::debugMessage](https://github.com/simplesamlphp/saml2/blob/4ef98dcf868312d11ea6c1acbebfe80483970d7f/src/SAML2/Compat/AbstractContainer.php#L25-L38) signature, `$message` could be a `string`or `\DOMElement`.  In `saml2 v3.2.*` the signature was incorrect, this method always could receive a DOMElement.

DOMElement is not stringable. In SimpleSAMLphp this method detects if the `$message` is a supported type (see [XML::debugSAMLMessage](https://github.com/simplesamlphp/simplesamlphp/blob/1b8f13438270f8e01959f7a1fcc28b5d52f5bdec/lib/SimpleSAML/Utils/XML.php#L107)).

```
    public static function debugSAMLMessage($message, $type)
    {
        if (!(is_string($type) && (is_string($message) || $message instanceof DOMElement))) {
            throw new \InvalidArgumentException('Invalid input parameters.');
        }
        // [...]
   }
```
This PR converts SAML message to string.
