### PR TITLE
Allow setting ForceAuthn on AuthnRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.10
+**New feature**
+* Allow setting the ForceAuthn property on AuthNRequest objects #96
+
 # 4.1.9
 **New feature**
 * Provide minimal Symfony 4 support #89 

--- a/src/DependencyInjection/SurfnetSamlExtension.php
+++ b/src/DependencyInjection/SurfnetSamlExtension.php
@@ -226,6 +226,7 @@ class SurfnetSamlExtension extends Extension
      */
     private function parseCertificateData($path, array $provider)
     {
+        $configuration = [];
         if (isset($provider['certificate_file']) && !isset($provider['certificate'])) {
             $configuration['certificateFile'] = $provider['certificate_file'];
         } elseif (isset($provider['certificate'])) {

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -148,6 +148,8 @@ class MetadataFactory
     private function getCertificateData($publicKeyFile)
     {
         $certificate = File::getFileContents($publicKeyFile);
+
+        $matches = [];
         preg_match(Certificate::CERTIFICATE_PATTERN, $certificate, $matches);
 
         $certificateData = str_replace(array(' ', "\n"), '', $matches[1]);

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -127,15 +127,20 @@ class AuthnRequestFactory
     /**
      * @param ServiceProvider  $serviceProvider
      * @param IdentityProvider $identityProvider
+     * @param bool $forceAuthn
      * @return AuthnRequest
      */
-    public static function createNewRequest(ServiceProvider $serviceProvider, IdentityProvider $identityProvider)
-    {
+    public static function createNewRequest(
+        ServiceProvider $serviceProvider,
+        IdentityProvider $identityProvider,
+        $forceAuthn = false
+    ) {
         $request = new SAML2AuthnRequest();
         $request->setAssertionConsumerServiceURL($serviceProvider->getAssertionConsumerUrl());
         $request->setDestination($identityProvider->getSsoUrl());
         $request->setIssuer($serviceProvider->getEntityId());
         $request->setProtocolBinding(Constants::BINDING_HTTP_POST);
+        $request->setForceAuthn($forceAuthn);
         $request->setSignatureKey(self::loadPrivateKey(
             $serviceProvider->getPrivateKey(PrivateKey::NAME_DEFAULT)
         ));


### PR DESCRIPTION
For now we could only get the state of the ForceAuthn flag. But where
not able to set it.

https://www.pivotaltracker.com/story/show/171101458