### PR TITLE
Allow retrieval of Scoping -> RequesterIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.11
+**New feature**
+* Allow retrieval of Scoping -> RequesterIds #97
+
 # 4.1.10
 **New feature**
 * Allow setting the ForceAuthn property on AuthNRequest objects #96

--- a/src/SAML2/ReceivedAuthnRequest.php
+++ b/src/SAML2/ReceivedAuthnRequest.php
@@ -206,6 +206,14 @@ final class ReceivedAuthnRequest
     }
 
     /**
+     * @return string[]
+     */
+    public function getScopingRequesterIds()
+    {
+        return $this->request->getRequesterID();
+    }
+    
+    /**
      * @param XMLSecurityKey $key
      * @return bool
      * @throws \Exception when signature is invalid (@see SAML2\Utils::validateSignature)


### PR DESCRIPTION
The requester ids can already be set as part of the setscoping method.
Now they can also be retrieved.

This feature is created to aid:
https://github.com/OpenConext/Stepup-gssp-bundle/pull/33
https://github.com/OpenConext/Stepup-Azure-MFA/pull/24