### PR TITLE
Add support for Extensions on AuthNRequests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "symfony/dependency-injection": "^4.4",
         "symfony/framework-bundle": "^4.4",
         "symfony/symfony": "^4.4",
-        "symfony/templating": "^4.4"
+        "symfony/templating": "^4.4",
+        "ext-dom": "*"
     },
     "require-dev": {
         "phpmd/phpmd": "^2.6",

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -360,4 +360,9 @@ class AuthnRequest
     {
         return $this->extensions;
     }
+
+    public function setExtensions(Extensions $extensions)
+    {
+        $this->extensions = $extensions;
+    }
 }

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -22,6 +22,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\Constants;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
+use Surfnet\SamlBundle\SAML2\Extensions\Extensions;
 
 class AuthnRequest
 {
@@ -51,11 +52,17 @@ class AuthnRequest
     private $signatureAlgorithm;
 
     /**
+     * @var Extensions
+     */
+    private $extensions;
+
+    /**
      * @param SAML2AuthnRequest $request
      */
     private function __construct(SAML2AuthnRequest $request)
     {
         $this->request = $request;
+        $this->extensions = Extensions::fromSaml2AuthNRequest($request);
     }
 
     /**
@@ -347,5 +354,10 @@ class AuthnRequest
         $signedQuery = $toSign . '&Signature=' . urlencode(base64_encode($signature));
 
         return $signedQuery;
+    }
+
+    public function getExtensions()
+    {
+        return $this->extensions;
     }
 }

--- a/src/SAML2/Extensions/Chunk.php
+++ b/src/SAML2/Extensions/Chunk.php
@@ -18,6 +18,8 @@
 
 namespace Surfnet\SamlBundle\SAML2\Extensions;
 
+use DOMElement;
+
 class Chunk
 {
     private $name;
@@ -27,11 +29,11 @@ class Chunk
     private $value;
 
     /**
-     * @param $name
-     * @param $namespace
-     * @param string|array $value
+     * @param string $name
+     * @param string $namespace
+     * @param DOMElement $value
      */
-    public function __construct($name, $namespace, $value)
+    public function __construct($name, $namespace, DOMElement $value)
     {
         $this->name = $name;
         $this->namespace = $namespace;
@@ -39,7 +41,7 @@ class Chunk
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getName()
     {
@@ -47,20 +49,15 @@ class Chunk
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getNamespace()
     {
         return $this->namespace;
     }
 
-    public function isCollection()
-    {
-        return is_array($this->value);
-    }
-
     /**
-     * @return mixed
+     * @return DOMElement
      */
     public function getValue()
     {

--- a/src/SAML2/Extensions/Chunk.php
+++ b/src/SAML2/Extensions/Chunk.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Copyright 2021 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\SAML2\Extensions;
+
+class Chunk
+{
+    private $name;
+
+    private $namespace;
+
+    private $value;
+
+    /**
+     * @param $name
+     * @param $namespace
+     * @param string|array $value
+     */
+    public function __construct($name, $namespace, $value)
+    {
+        $this->name = $name;
+        $this->namespace = $namespace;
+        $this->value = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    public function isCollection()
+    {
+        return is_array($this->value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/SAML2/Extensions/Extensions.php
+++ b/src/SAML2/Extensions/Extensions.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright 2021 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\SAML2\Extensions;
+
+use SAML2\AuthnRequest;
+use function array_key_exists;
+
+class Extensions
+{
+    private $chunks = [];
+
+    public static function fromSaml2AuthNRequest(AuthnRequest $authnRequest)
+    {
+        $extensions = new self();
+        if (!empty($authnRequest->getExtensions())) {
+            $rawExtensions = $authnRequest->getExtensions();
+            foreach ($rawExtensions as $rawChunk) {
+                $extensions->addChunk(
+                    new Chunk(
+                        $rawChunk->localName,
+                        $rawChunk->namespaceURI,
+                        $rawChunk->xml
+                    )
+                );
+
+            }
+        }
+        return $extensions;
+    }
+
+    /**
+     * @param string $name
+     * @return Chunk|null
+     */
+    public function findByName($name)
+    {
+        if (array_key_exists($name, $this->chunks)) {
+            return $this->chunks[$name];
+        }
+        return null;
+    }
+
+    private function addChunk(Chunk $chunk)
+    {
+        $this->chunks[$chunk->getName()] = $chunk;
+    }
+}

--- a/src/SAML2/Extensions/Extensions.php
+++ b/src/SAML2/Extensions/Extensions.php
@@ -19,10 +19,13 @@
 namespace Surfnet\SamlBundle\SAML2\Extensions;
 
 use SAML2\AuthnRequest;
-use function array_key_exists;
+use SAML2\XML\Chunk as SAML2Chunk;
 
 class Extensions
 {
+    /**
+     * @var Chunk[]
+     */
     private $chunks = [];
 
     public static function fromSaml2AuthNRequest(AuthnRequest $authnRequest)
@@ -38,7 +41,6 @@ class Extensions
                         $rawChunk->xml
                     )
                 );
-
             }
         }
         return $extensions;
@@ -56,8 +58,20 @@ class Extensions
         return null;
     }
 
-    private function addChunk(Chunk $chunk)
+    public function addChunk(Chunk $chunk)
     {
         $this->chunks[$chunk->getName()] = $chunk;
+    }
+
+    /**
+     * @return array
+     */
+    public function toSaml2Format()
+    {
+        $extensions = [];
+        foreach ($this->chunks as $chunk) {
+            $extensions[] = new SAML2Chunk($chunk->getValue());
+        }
+        return $extensions;
     }
 }

--- a/src/SAML2/ReceivedAuthnRequest.php
+++ b/src/SAML2/ReceivedAuthnRequest.php
@@ -25,6 +25,7 @@ use SAML2\DOMDocumentFactory;
 use SAML2\Message;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\Exception\RuntimeException;
+use Surfnet\SamlBundle\SAML2\Extensions\Extensions;
 
 final class ReceivedAuthnRequest
 {
@@ -32,6 +33,10 @@ final class ReceivedAuthnRequest
      * @var SAML2AuthnRequest
      */
     private $request;
+    /**
+     * @var Extensions
+     */
+    private $extensions;
 
     private function __construct(SAML2AuthnRequest $request)
     {
@@ -221,5 +226,15 @@ final class ReceivedAuthnRequest
     public function verify(XMLSecurityKey $key)
     {
         return $this->request->validate($key);
+    }
+
+    public function getExtensions()
+    {
+        return $this->extensions;
+    }
+
+    public function setExtensions(Extensions $extensions)
+    {
+        $this->extensions = $extensions;
     }
 }

--- a/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
+++ b/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright 2021 SURF B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Tests\Component\Extensions;
+
+use DOMElement;
+use PHPUnit_Framework_TestCase as TestCase;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\AuthnRequest as SAML2AuthnRequest;
+use SAML2\DOMDocumentFactory;
+use Surfnet\SamlBundle\SAML2\AuthnRequest;
+use Surfnet\SamlBundle\SAML2\Extensions\Chunk;
+use Surfnet\SamlBundle\SAML2\Extensions\Extensions;
+use function file_get_contents;
+use function is_array;
+
+class AuthnRequestExtensionsTest extends TestCase
+{
+
+    public function test_extensions_are_retrievable()
+    {
+        $authnRequest = $this->createSignedAuthnRequest(
+            [$this, 'encodeDataToSignWithPhpsHttpBuildQuery']
+        );
+        self::assertInstanceOf(AuthnRequest::class, $authnRequest);
+
+        $extentions = $authnRequest->getExtensions();
+        self::assertInstanceOf(Extensions::class, $extentions);
+        $chunk = $extentions->findByName('UserAttributes');
+        self::assertInstanceOf(Chunk::class, $chunk);
+        self::assertEquals('UserAttributes', $chunk->getName());
+        self::assertEquals('urn:mace:surf.nl:stepup:gssp-extensions', $chunk->getNamespace());
+        self::assertInstanceOf(DOMElement::class, $chunk->getValue());
+    }
+
+    /**
+     * @param array $params
+     * @return string
+     */
+    private function encodeDataToSignWithPhpsHttpBuildQuery(array $params)
+    {
+        return http_build_query($params);
+    }
+
+    /**
+     * @param callable $prepareDataToSign Expects an associative array of data to sign and returns a string to sign
+     * @param null|string $customSignature Signature to be used instead of signature to sign data to sign with
+     * @return AuthnRequest
+     */
+    private function createSignedAuthnRequest(callable $prepareDataToSign, $customSignature = null)
+    {
+        $keyData    = file_get_contents(__DIR__.'/../../../Resources/keys/development_privatekey.pem');
+        $privateKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
+        $privateKey->loadKey($keyData);
+
+        $domDocument          = DOMDocumentFactory::fromString(file_get_contents(__DIR__ . '/with_extensions.xml'));
+        $unsignedAuthnRequest = SAML2AuthnRequest::fromXML($domDocument->firstChild);
+
+        $requestAsXml   = $unsignedAuthnRequest->toUnsignedXML()->ownerDocument->saveXML();
+        $encodedRequest = base64_encode(gzdeflate($requestAsXml));
+        $queryParams    = [AuthnRequest::PARAMETER_REQUEST => $encodedRequest];
+
+        $queryParams[AuthnRequest::PARAMETER_SIGNATURE_ALGORITHM] = $privateKey->type;
+
+        $toSign = $prepareDataToSign($queryParams);
+        if ($customSignature === null) {
+            $signature = base64_encode($privateKey->signData($toSign));
+        } else {
+            $signature = base64_encode($customSignature);
+        }
+
+        $saml2AuthnRequest = SAML2AuthnRequest::fromXML($unsignedAuthnRequest->toUnsignedXML());
+
+        return AuthnRequest::createSigned(
+            $saml2AuthnRequest,
+            $encodedRequest,
+            null,
+            $signature,
+            $privateKey->type
+        );
+    }
+}

--- a/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
+++ b/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\SamlBundle\Tests\Component\Extensions;
 
 use DOMElement;
+use Mockery as m;
 use PHPUnit_Framework_TestCase as TestCase;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
@@ -27,7 +28,6 @@ use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\Extensions\Chunk;
 use Surfnet\SamlBundle\SAML2\Extensions\Extensions;
 use function file_get_contents;
-use function is_array;
 
 class AuthnRequestExtensionsTest extends TestCase
 {
@@ -48,6 +48,27 @@ class AuthnRequestExtensionsTest extends TestCase
         self::assertInstanceOf(DOMElement::class, $chunk->getValue());
     }
 
+    public function test_setting_of_extensions()
+    {
+        $authnRequest = $this->createSignedAuthnRequest(
+            [$this, 'encodeDataToSignWithPhpsHttpBuildQuery'],
+            null,
+            '/without_extensions.xml'
+        );
+
+        $extensions = new Extensions();
+        $rawData = new DOMElement('foobar');
+        $chunk = new Chunk('UserAttributes', 'urn:mace:surf.nl:stepup:gssp-extensions', $rawData);
+        $extensions->addChunk($chunk);
+
+        $authnRequest->setExtensions($extensions);
+
+        // Kind of sad, but we need to perform some assertions.
+        $extensions = $authnRequest->getExtensions();
+        self::assertInstanceOf(Extensions::class, $extensions);
+        self::assertEquals('UserAttributes', $extensions->findByName('UserAttributes')->getName());
+    }
+
     /**
      * @param array $params
      * @return string
@@ -60,15 +81,20 @@ class AuthnRequestExtensionsTest extends TestCase
     /**
      * @param callable $prepareDataToSign Expects an associative array of data to sign and returns a string to sign
      * @param null|string $customSignature Signature to be used instead of signature to sign data to sign with
+     * @param string $source
      * @return AuthnRequest
+     * @throws \Exception
      */
-    private function createSignedAuthnRequest(callable $prepareDataToSign, $customSignature = null)
-    {
+    private function createSignedAuthnRequest(
+        callable $prepareDataToSign,
+        $customSignature = null,
+        $source = '/with_extensions.xml'
+    ) {
         $keyData    = file_get_contents(__DIR__.'/../../../Resources/keys/development_privatekey.pem');
         $privateKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
         $privateKey->loadKey($keyData);
 
-        $domDocument          = DOMDocumentFactory::fromString(file_get_contents(__DIR__ . '/with_extensions.xml'));
+        $domDocument          = DOMDocumentFactory::fromString(file_get_contents(__DIR__ . $source));
         $unsignedAuthnRequest = SAML2AuthnRequest::fromXML($domDocument->firstChild);
 
         $requestAsXml   = $unsignedAuthnRequest->toUnsignedXML()->ownerDocument->saveXML();

--- a/src/Tests/Component/Extensions/with_extensions.xml
+++ b/src/Tests/Component/Extensions/with_extensions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    ID="_92dbb2d48fa7962f3523ea301e85ec5dc52b2d09d9affc84e9b8163c843f" Version="2.0"
+                    IssueInstant="2017-04-18T07:46:45Z" Destination="https://tiqr.tld/saml/sso"
+                    AssertionConsumerServiceURL="https://gateway.tld/gssp/tiqr/consume-assertion"
+                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
+    <saml:Issuer>https://gateway.example.com/gssp/tiqr/metadata</saml:Issuer>
+    <samlp:Extensions>
+        <gssp:UserAttributes xmlns:gssp="urn:mace:surf.nl:stepup:gssp-extensions"
+                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                             xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <saml:Attribute Name="urn:mace:dir:attribute-def:mail"
+                            NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue xsi:type="xs:string">user@example.com</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute Name="urn:mace:dir:attribute-def:surname"
+                            NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:string">
+                <saml:AttributeValue xsi:type="xs:string">foobar</saml:AttributeValue>
+            </saml:Attribute>
+        </gssp:UserAttributes>
+    </samlp:Extensions>
+    <samlp:Scoping ProxyCount="10">
+        <samlp:RequesterID>https://selfservice.stepup.example.com/registration/gssf/tiqr/metadata</samlp:RequesterID>
+    </samlp:Scoping>
+</samlp:AuthnRequest>

--- a/src/Tests/Component/Extensions/without_extensions.xml
+++ b/src/Tests/Component/Extensions/without_extensions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    ID="_92dbb2d48fa7962f3523ea301e85ec5dc52b2d09d9affc84e9b8163c843f" Version="2.0"
+                    IssueInstant="2017-04-18T07:46:45Z" Destination="https://tiqr.tld/saml/sso"
+                    AssertionConsumerServiceURL="https://gateway.tld/gssp/tiqr/consume-assertion"
+                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
+    <saml:Issuer>https://gateway.example.com/gssp/tiqr/metadata</saml:Issuer>
+    <samlp:Scoping ProxyCount="10">
+        <samlp:RequesterID>https://selfservice.stepup.example.com/registration/gssf/tiqr/metadata</samlp:RequesterID>
+    </samlp:Scoping>
+</samlp:AuthnRequest>


### PR DESCRIPTION
Task 1 of: https://www.pivotaltracker.com/story/show/175121584

Todo: The Extensions should still be set on the original (decorated) authnrequest. Should be easy as calling the corresponding setter on it.