### PR TITLE
Allow long classnames

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -30,6 +30,7 @@
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable" />
         <exclude name="LongVariable" />
+        <exclude name="LongClassName" />
     </rule>
 
 </ruleset>

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -7,3 +7,4 @@
 
 date.timezone = "Europe/Amsterdam"
 memory_limit = 2048M
+xdebug.mode = "coverage"


### PR DESCRIPTION
This will make the phpmd ruleset compatible with the project
setup.