### PR TITLE
Secure the way the verifySignature method is used

### DIFF
--- a/src/Entity/HostedEntities.php
+++ b/src/Entity/HostedEntities.php
@@ -142,7 +142,7 @@ class HostedEntities
 
         $context = $this->router->getContext();
 
-        $context->fromRequest($this->requestStack->getMasterRequest());
+        $context->fromRequest($this->requestStack->getMainRequest());
 
         $url = $this->router->generate($route, $parameters, RouterInterface::ABSOLUTE_URL);
 

--- a/src/Http/ReceivedAuthnRequestQueryString.php
+++ b/src/Http/ReceivedAuthnRequestQueryString.php
@@ -288,9 +288,10 @@ final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
      */
     public function verify(XMLSecurityKey $key)
     {
-        if ($key->verifySignature($this->getSignedRequestPayload(), $this->getDecodedSignature())) {
-            return true;
+        $isVerified = $key->verifySignature($this->getSignedRequestPayload(), $this->getDecodedSignature());
+        if ($isVerified !== 1) {
+            return false;
         }
-        return false;
+        return true;
     }
 }

--- a/src/Signing/SignatureVerifier.php
+++ b/src/Signing/SignatureVerifier.php
@@ -21,7 +21,7 @@ namespace Surfnet\SamlBundle\Signing;
 use Psr\Log\LoggerInterface;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Certificate\Key;
-use SAML2\Certificate\KeyLoader as KeyLoader;
+use SAML2\Certificate\KeyLoader;
 use SAML2\Certificate\X509;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestQueryString;
@@ -151,13 +151,13 @@ class SignatureVerifier
         $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
         $key->loadKey($publicKey->getCertificate());
 
-        if ($key->verifySignature($request->getSignedRequestQuery(), $request->getSignature())) {
-            $this->logger->debug('Signature VERIFIED');
-            return true;
+        $isVerified = $key->verifySignature($request->getSignedRequestQuery(), $request->getSignature());
+        if ($isVerified !== 1) {
+            $this->logger->debug('Signature NOT VERIFIED');
+            return false;
         }
 
-        $this->logger->debug('Signature NOT VERIFIED');
-
-        return false;
+        $this->logger->debug('Signature VERIFIED');
+        return true;
     }
 }


### PR DESCRIPTION
It either returns bool, int: 1, 0 or -1 and -1 will be evaluated to be true in PHP. Making the use of this method unsafe when not strictly testing for the desired outcome.