### PR TITLE
Set correct template reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.3.1
+**Bugfix**
+* Update metadata.xml template reference
+
 # 4.3.0
 **New feature**
 * Further support Symfony 4 by adhering to the Twig environment in favor of

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -88,7 +88,7 @@ class MetadataFactory
 
         $metadata->document = DOMDocumentFactory::create();
         $metadata->document->loadXML($this->templateEngine->render(
-            'SurfnetSamlBundle:Metadata:metadata.xml.twig',
+            '@SurfnetSaml/Metadata/metadata.xml.twig',
             ['metadata' => $metadata]
         ));
 

--- a/src/Tests/Component/Metadata/MetadataFactoryTest.php
+++ b/src/Tests/Component/Metadata/MetadataFactoryTest.php
@@ -48,7 +48,7 @@ class MetadataFactoryTest extends TestCase
         // Load the XML template from filesystem as the FilesystemLoader does not honour the bundle prefix
         $loader = new ArrayLoader(
             [
-                'SurfnetSamlBundle:Metadata:metadata.xml.twig' => file_get_contents('src/Resources/views/Metadata/metadata.xml.twig')
+                '@SurfnetSaml/Metadata/metadata.xml.twig' => file_get_contents('src/Resources/views/Metadata/metadata.xml.twig')
             ]
         );
         $this->twig = new Environment($loader);


### PR DESCRIPTION
The template reference is not compatible with the Twig Enviroment template parser. It can not find templates using the old naming convention. This change fixes that problem.