### PR TITLE
Add internal-collabPersonId to attribute dictionary

### DIFF
--- a/src/Resources/config/saml_attributes.yml
+++ b/src/Resources/config/saml_attributes.yml
@@ -170,6 +170,15 @@ services:
         tags:
             - { name: 'saml.attribute' }
 
+    saml.attribute.internalCollabPersonId:
+        class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
+        arguments:
+            - internalCollabPersonId
+            - 'urn:mace:surf.nl:attribute-def:internal-collabPersonId'
+            - ~
+        tags:
+            - { name: 'saml.attribute' }
+
     saml.attribute.isMemberOf:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
         arguments:


### PR DESCRIPTION
This will be used to pass along the internal collabPersonId in authentications where a trusted proxy is involved.
