### PR TITLE
Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/
 .idea
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ language: php
 
 matrix:
   include:
-    - php: 7.2
     - php: 7.3
+    - php: 7.4
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "^9.5",
         "psr/log": "~1.0",
-        "sebastian/exporter": "~2.0",
+        "sebastian/exporter": "^4.0.5",
         "sebastian/phpcpd": "^2.0",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/phpunit-bridge": "^4.4"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/dependency-injection": "^4.4",
         "symfony/framework-bundle": "^4.4",
         "symfony/templating": "^4.4",
-        "twig/twig": "^2"
+        "twig/twig": "^2 || ^3"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/dependency-injection": "^4.4",
         "symfony/framework-bundle": "^4.4",
         "symfony/templating": "^4.4",
-        "twig/twig": "^2 || ^3"
+        "twig/twig": "^2 || ^3",
+        "vimeo/psalm": "^4.30"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "jasny/phpunit-xsdvalidation": "^1.0",
-        "mockery/mockery": "~0.9",
+        "mockery/mockery": "^1.5",
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "^9.5",
         "psr/log": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.2,<8.0-dev",
         "ext-dom": "*",
         "ext-openssl": "*",
-        "robrichards/xmlseclibs": "^3.0.4",
+        "robrichards/xmlseclibs": "^3.1.1",
         "simplesamlphp/saml2": "3.2.*",
         "symfony/dependency-injection": "^4.4",
         "symfony/framework-bundle": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.2,<8.0-dev",
+        "php": ">=7.3,<8.0-dev",
         "ext-dom": "*",
         "ext-openssl": "*",
         "robrichards/xmlseclibs": "^3.1.1",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpunit/phpunit": "^9.5",
         "psr/log": "~1.0",
         "sebastian/exporter": "^4.0.5",
-        "sebastian/phpcpd": "^2.0",
+        "sebastian/phpcpd": "^6.0",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/phpunit-bridge": "^4.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-dom": "*",
         "ext-openssl": "*",
         "robrichards/xmlseclibs": "^3.1.1",
-        "simplesamlphp/saml2": "3.2.*",
+        "simplesamlphp/saml2": "^4.6.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/framework-bundle": "^4.4",
         "symfony/templating": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "symfony/dependency-injection": "^4.4",
         "symfony/framework-bundle": "^4.4",
         "symfony/templating": "^4.4",
-        "twig/twig": "^2 || ^3",
-        "vimeo/psalm": "^4.30"
+        "twig/twig": "^2 || ^3"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr/log": "~1.0",
         "sebastian/exporter": "^4.0.5",
         "sebastian/phpcpd": "^6.0",
-        "squizlabs/php_codesniffer": "^3.0",
+        "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/phpunit-bridge": "^4.4"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "twig/twig": "^2"
     },
     "require-dev": {
-        "jasny/phpunit-xsdvalidation": "^1.0",
         "mockery/mockery": "^1.5",
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "jasny/phpunit-xsdvalidation": "^1.0",
         "mockery/mockery": "~0.9",
         "phpmd/phpmd": "^2.6",
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^9.5",
         "psr/log": "~1.0",
         "sebastian/exporter": "~2.0",
         "sebastian/phpcpd": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "phpmd/phpmd": "^2.6",
+        "phpmd/phpmd": "^2.13",
         "phpunit/phpunit": "^9.5",
         "psr/log": "~1.0",
         "sebastian/exporter": "^4.0.5",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,4 +29,8 @@
         <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
         <listener class="\Mockery\Adapter\Phpunit\TestListener"/>
     </listeners>
+    <php>
+        <server name="KERNEL_CLASS" value="App\Kernel"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=3"/>
+    </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="src/Tests/Bootstrap.php">
     <testsuites>
         <testsuite name="Unit">
@@ -18,14 +17,14 @@
             <directory>src/Tests/Component</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory>src</directory>
-            <exclude>
-                <directory>src/Tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>src/Tests</directory>
+        </exclude>
+    </coverage>
     <listeners>
         <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
         <listener class="\Mockery\Adapter\Phpunit\TestListener"/>

--- a/src/Resources/config/saml_attributes.yml
+++ b/src/Resources/config/saml_attributes.yml
@@ -1,4 +1,22 @@
 services:
+    saml.attribute.subjectId:
+        class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
+        arguments:
+            - subjectId
+            - 'urn:oasis:names:tc:SAML:attribute:subject-id'
+            - ~
+        tags:
+            - { name: 'saml.attribute' }
+
+    saml.attribute.pairwiseId:
+        class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
+        arguments:
+            - pairwiseId
+            - 'urn:oasis:names:tc:SAML:attribute:pairwise-id'
+            - ~
+        tags:
+            - { name: 'saml.attribute' }
+
     saml.attribute.commonName:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
         arguments:

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -21,6 +21,7 @@ namespace Surfnet\SamlBundle\SAML2;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\Constants;
+use SAML2\XML\saml\NameID;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\SAML2\Extensions\ExtensionsMapperTrait;
 
@@ -168,13 +169,7 @@ class AuthnRequest
      */
     public function getNameId()
     {
-        $nameId = $this->request->getNameId();
-
-        if (!isset($nameId->value)) {
-            return;
-        }
-
-        return $nameId->value;
+        return $this->request->getNameId();
     }
 
     /**
@@ -192,23 +187,23 @@ class AuthnRequest
     }
 
     /**
-     * @param string      $nameId
+     * @param string      $nameIdValue
      * @param string|null $format
      */
-    public function setSubject($nameId, $format = null)
+    public function setSubject($nameIdValue, $format = null)
     {
-        if (!is_string($nameId)) {
-            throw InvalidArgumentException::invalidType('string', 'nameId', $nameId);
+        if (!is_string($nameIdValue)) {
+            throw InvalidArgumentException::invalidType('string', 'nameId', $nameIdValue);
         }
 
         if (!is_null($format) && !is_string($format)) {
             throw InvalidArgumentException::invalidType('string', 'format', $format);
         }
 
-        $nameId = [
-            'Value' => $nameId,
-            'Format' => ($format ?: Constants::NAMEID_UNSPECIFIED)
-        ];
+
+        $nameId = new NameID();
+        $nameId->setValue($nameId);
+        $nameId->setFormat($format ?: Constants::NAMEID_UNSPECIFIED);
 
         $this->request->setNameId($nameId);
     }

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -169,7 +169,7 @@ class AuthnRequest
      */
     public function getNameId()
     {
-        return $this->request->getNameId();
+        return $this->request->getNameId()->getValue();
     }
 
     /**

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -177,13 +177,7 @@ class AuthnRequest
      */
     public function getNameIdFormat()
     {
-        $nameId = $this->request->getNameId();
-
-        if (!isset($nameId->Format)) {
-            return;
-        }
-
-        return $nameId->Format;
+        return $this->request->getNameId()->getFormat();
     }
 
     /**
@@ -202,7 +196,7 @@ class AuthnRequest
 
 
         $nameId = new NameID();
-        $nameId->setValue($nameId);
+        $nameId->setValue($nameIdValue);
         $nameId->setFormat($format ?: Constants::NAMEID_UNSPECIFIED);
 
         $this->request->setNameId($nameId);

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -25,6 +25,7 @@ use SAML2\Configuration\PrivateKey;
 use SAML2\Constants;
 use SAML2\DOMDocumentFactory;
 use SAML2\Message;
+use SAML2\XML\saml\Issuer;
 use Surfnet\SamlBundle\Entity\IdentityProvider;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Exception\RuntimeException;
@@ -138,7 +139,9 @@ class AuthnRequestFactory
         $request = new SAML2AuthnRequest();
         $request->setAssertionConsumerServiceURL($serviceProvider->getAssertionConsumerUrl());
         $request->setDestination($identityProvider->getSsoUrl());
-        $request->setIssuer($serviceProvider->getEntityId());
+        $issuer = new Issuer();
+        $issuer->setValue($serviceProvider->getEntityId());
+        $request->setIssuer($issuer);
         $request->setProtocolBinding(Constants::BINDING_HTTP_POST);
         $request->setForceAuthn($forceAuthn);
         $request->setSignatureKey(self::loadPrivateKey(

--- a/src/SAML2/BridgeContainer.php
+++ b/src/SAML2/BridgeContainer.php
@@ -39,9 +39,9 @@ class BridgeContainer extends AbstractContainer
     }
 
     /**
-     * @return LoggerInterface
+     * @return \Psr\Log\LoggerInterface
      */
-    public function getLogger()
+    public function getLogger(): LoggerInterface
     {
         return $this->logger;
     }
@@ -49,12 +49,12 @@ class BridgeContainer extends AbstractContainer
     /**
      * Generate a random identifier for identifying SAML2 documents.
      */
-    public function generateId()
+    public function generateId(): string
     {
         return '_' . bin2hex(openssl_random_pseudo_bytes(30));
     }
 
-    public function debugMessage($message, $type)
+    public function debugMessage($message, string $type): void
     {
         if ($message instanceof \DOMElement) {
             $message = $message->ownerDocument->saveXML($message);
@@ -63,7 +63,7 @@ class BridgeContainer extends AbstractContainer
         $this->logger->debug($message, ['type' => $type]);
     }
 
-    public function redirect($url, $data = array())
+    public function redirect(string $url, array $data = []): void
     {
         throw new BadMethodCallException(sprintf(
             "%s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
@@ -72,12 +72,35 @@ class BridgeContainer extends AbstractContainer
         ));
     }
 
-    public function postRedirect($url, $data = array())
+    public function postRedirect(string $url, array $data = []): void
     {
         throw new BadMethodCallException(sprintf(
             "%s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
             __CLASS__,
             __METHOD__
         ));
+    }
+
+    /**
+     * @return string
+     */
+    public function getTempDir() : string
+    {
+        return sys_get_temp_dir();
+    }
+
+    /**
+     * @param string $filename
+     * @param string $data
+     * @param int|null $mode
+     * @return void
+     */
+    public function writeFile(string $filename, string $data, int $mode = null) : void
+    {
+        if ($mode === null) {
+            $mode = 0600;
+        }
+        file_put_contents($filename, $data);
+        chmod($filename, $mode);
     }
 }

--- a/src/SAML2/Extensions/ExtensionsMapperTrait.php
+++ b/src/SAML2/Extensions/ExtensionsMapperTrait.php
@@ -19,18 +19,18 @@ trait ExtensionsMapperTrait
             $rawExtensions = $this->request->getExtensions();
             /** @var SAML2Chunk $rawChunk */
             foreach ($rawExtensions as $rawChunk) {
-                switch ($rawChunk->localName) {
+                switch ($rawChunk->getLocalName()) {
                     case 'UserAttributes':
                         $this->extensions->addChunk(
-                            new GsspUserAttributesChunk($rawChunk->xml)
+                            new GsspUserAttributesChunk($rawChunk->getXML())
                         );
                         break;
                     default:
                         $this->extensions->addChunk(
                             new Chunk(
-                                $rawChunk->localName,
-                                $rawChunk->namespaceURI,
-                                $rawChunk->xml
+                                $rawChunk->getLocalName(),
+                                $rawChunk->getNamespaceURI(),
+                                $rawChunk->getXML()
                             )
                         );
                 }

--- a/src/SAML2/ReceivedAuthnRequest.php
+++ b/src/SAML2/ReceivedAuthnRequest.php
@@ -105,7 +105,7 @@ final class ReceivedAuthnRequest
             return null;
         }
 
-        return $nameId->value;
+        return $nameId->getValue();
     }
 
     /**
@@ -118,7 +118,7 @@ final class ReceivedAuthnRequest
             return null;
         }
 
-        return $nameId->Format;
+        return $nameId->getFormat();
     }
 
     /**

--- a/src/SAML2/Response/Assertion/InResponseTo.php
+++ b/src/SAML2/Response/Assertion/InResponseTo.php
@@ -48,10 +48,10 @@ class InResponseTo
 
         /** @var \SAML2\XML\saml\SubjectConfirmation $subjectConfirmation */
         $subjectConfirmation = $subjectConfirmationArray[0];
-        if (!$subjectConfirmation->SubjectConfirmationData) {
+        if (!$subjectConfirmation->getSubjectConfirmationData()) {
             return null;
         }
 
-        return $subjectConfirmation->SubjectConfirmationData->InResponseTo;
+        return $subjectConfirmation->getSubjectConfirmationData()->getInResponseTo();
     }
 }

--- a/src/SAML2/Response/AssertionAdapter.php
+++ b/src/SAML2/Response/AssertionAdapter.php
@@ -54,7 +54,7 @@ class AssertionAdapter
     {
         $data = $this->assertion->getNameId();
         if ($data) {
-            return $data->value;
+            return $data->getValue();
         }
 
         return null;

--- a/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
+++ b/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Component\Extensions;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\DOMDocumentFactory;

--- a/src/Tests/Component/Extensions/ChunkSerializationTest.php
+++ b/src/Tests/Component/Extensions/ChunkSerializationTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Component\Extensions;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Surfnet\SamlBundle\SAML2\Extensions\GsspUserAttributesChunk;
 
 class ChunkSerializationTest extends TestCase

--- a/src/Tests/Component/Metadata/MetadataFactoryTest.php
+++ b/src/Tests/Component/Metadata/MetadataFactoryTest.php
@@ -167,9 +167,7 @@ XML;
 
         while ($xmlReader->read()) {
             if (!$xmlReader->isValid()) {
-                if ($err instanceof libXMLError) {
-                    return false;
-                }
+                return false;
             }
         }
 

--- a/src/Tests/Component/Metadata/MetadataFactoryTest.php
+++ b/src/Tests/Component/Metadata/MetadataFactoryTest.php
@@ -119,7 +119,8 @@ XML;
         $metadata = $this->factory->generate();
         self::assertEquals($expectedResult, $metadata->__toString());
 
-        $document = XMLReader::XML($metadata->__toString());
+        $document = new XMLReader();
+        $document->XML($metadata->__toString());
         $this->assertTrue($this->validateDocument($document, __DIR__ . '/xsd/metadata.xsd'));
     }
 
@@ -139,7 +140,8 @@ XML;
         $this->buildFactory($metadataConfiguration, $signingService);
         $metadata = $this->factory->generate();
 
-        $document = XMLReader::XML($metadata->__toString());
+        $document = new XMLReader();
+        $document->XML($metadata->__toString());
         $this->assertTrue($this->validateDocument($document, __DIR__ . '/xsd/metadata.xsd'));
     }
 

--- a/src/Tests/Component/Metadata/MetadataFactoryTest.php
+++ b/src/Tests/Component/Metadata/MetadataFactoryTest.php
@@ -20,7 +20,7 @@ namespace Surfnet\SamlBundle\Tests\Component\Metadata;
 
 use Jasny\PHPUnit\Constraint\XSDValidation;
 use Mockery as m;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use SAML2\Certificate\KeyLoader;
 use SAML2\Certificate\PrivateKeyLoader;
 use Surfnet\SamlBundle\Metadata\MetadataConfiguration;
@@ -43,7 +43,7 @@ class MetadataFactoryTest extends TestCase
 
     public $signingService;
 
-    public function setUp()
+    public function setUp(): void
     {
         // Load the XML template from filesystem as the FilesystemLoader does not honour the bundle prefix
         $loader = new ArrayLoader(

--- a/src/Tests/Component/Metadata/MetadataFactoryTest.php
+++ b/src/Tests/Component/Metadata/MetadataFactoryTest.php
@@ -20,7 +20,7 @@ namespace Surfnet\SamlBundle\Tests\Component\Metadata;
 
 use Jasny\PHPUnit\Constraint\XSDValidation;
 use Mockery as m;
-use PHPUnit\Framework\TestCase as TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use SAML2\Certificate\KeyLoader;
 use SAML2\Certificate\PrivateKeyLoader;
 use Surfnet\SamlBundle\Metadata\MetadataConfiguration;
@@ -30,9 +30,10 @@ use Surfnet\SamlBundle\Signing\Signable;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Loader\ArrayLoader;
 use Twig\Environment;
+
 use function file_get_contents;
 
-class MetadataFactoryTest extends TestCase
+class MetadataFactoryTest extends MockeryTestCase
 {
     /** @var MetadataFactory */
     public $factory;

--- a/src/Tests/Component/Signing/AuthnRequestSigningTest.php
+++ b/src/Tests/Component/Signing/AuthnRequestSigningTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Component\Signing;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Psr\Log\NullLogger;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\AuthnRequest as SAML2AuthnRequest;

--- a/src/Tests/TestSaml2Container.php
+++ b/src/Tests/TestSaml2Container.php
@@ -18,57 +18,134 @@
 
 namespace Surfnet\SamlBundle\Tests;
 
-use SAML2\Compat\AbstractContainer;
+use BadMethodCallException;
 use Psr\Log\LoggerInterface;
+use SAML2\Compat\AbstractContainer;
+
+use function chmod;
+use function file_get_contents;
+use function sprintf;
+use function sys_get_temp_dir;
 
 class TestSaml2Container extends AbstractContainer
 {
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private $logger;
+    /** @var \Psr\Log\LoggerInterface */
+    private LoggerInterface $logger;
 
+
+    /**
+     * Get a PSR-3 compatible logger.
+     * @return \Psr\Log\LoggerInterface
+     */
     public function __construct(LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }
 
+
     /**
-     * @return LoggerInterface
+     * @return \Psr\Log\LoggerInterface
      */
-    public function getLogger()
+    public function getLogger(): LoggerInterface
     {
         return $this->logger;
     }
 
+
     /**
      * Generate a random identifier for identifying SAML2 documents.
+     * @return string
      */
-    public function generateId()
+    public function generateId(): string
     {
-        return 1;
+        return '1';
     }
 
-    public function debugMessage($message, $type)
+
+    /**
+     * Log an incoming message to the debug log.
+     *
+     * Type can be either:
+     * - **in** XML received from third party
+     * - **out** XML that will be sent to third party
+     * - **encrypt** XML that is about to be encrypted
+     * - **decrypt** XML that was just decrypted
+     *
+     * @param \DOMElement|string $message
+     * @param string $type
+     * @return void
+     */
+    public function debugMessage($message, string $type): void
     {
         $this->logger->debug($message, ['type' => $type]);
     }
 
-    public function redirect($url, $data = array())
+
+    /**
+     * Trigger the user to perform a GET to the given URL with the given data.
+     *
+     * @param string $url
+     * @param array $data
+     * @return void
+     */
+    public function redirect(string $url, array $data = []): void
     {
-        throw new \BadMethodCallException(sprintf(
+        throw new BadMethodCallException(sprintf(
             "[TEST] %s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
             __CLASS__,
             __METHOD__
         ));
     }
 
-    public function postRedirect($url, $data = array())
+
+    /**
+     * Trigger the user to perform a POST to the given URL with the given data.
+     *
+     * @param string $url
+     * @param array $data
+     * @return void
+     */
+    public function postRedirect(string $url, array $data = []): void
     {
-        throw new \BadMethodCallException(sprintf(
+        throw new BadMethodCallException(sprintf(
             "[TEST] %s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
             __CLASS__,
             __METHOD__
         ));
+    }
+
+
+    /**
+     * This function retrieves the path to a directory where temporary files can be saved.
+     *
+     * @throws \Exception If the temporary directory cannot be created or it exists and does not belong
+     * to the current user.
+     * @return string Path to a temporary directory, without a trailing directory separator.
+     */
+    public function getTempDir(): string
+    {
+        return sys_get_temp_dir();
+    }
+
+
+    /**
+     * Atomically write a file.
+     *
+     * This is a helper function for writing data atomically to a file. It does this by writing the file data to a
+     * temporary file, then renaming it to the required file name.
+     *
+     * @param string $filename The path to the file we want to write to.
+     * @param string $data The data we should write to the file.
+     * @param int $mode The permissions to apply to the file. Defaults to 0600.
+     * @return void
+     */
+    public function writeFile(string $filename, string $data, int $mode = null): void
+    {
+        if ($mode === null) {
+            $mode = 0600;
+        }
+
+        file_put_contents($filename, $data);
+        chmod($filename, $mode);
     }
 }

--- a/src/Tests/TestSaml2Container.php
+++ b/src/Tests/TestSaml2Container.php
@@ -30,7 +30,7 @@ use function sys_get_temp_dir;
 class TestSaml2Container extends AbstractContainer
 {
     /** @var \Psr\Log\LoggerInterface */
-    private LoggerInterface $logger;
+    private $logger;
 
 
     /**

--- a/src/Tests/Unit/Http/HttpBindingFactoryTest.php
+++ b/src/Tests/Unit/Http/HttpBindingFactoryTest.php
@@ -19,12 +19,13 @@
 namespace Surfnet\SamlBundle\Tests\Http;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\TestCase as UnitTest;
 use Surfnet\SamlBundle\Http\HttpBindingFactory;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
-class HttpBindingFactoryTest extends UnitTest
+class HttpBindingFactoryTest extends MockeryTestCase
 {
     /** @var HttpBindingFactory */
     private $factory;

--- a/src/Tests/Unit/Http/HttpBindingFactoryTest.php
+++ b/src/Tests/Unit/Http/HttpBindingFactoryTest.php
@@ -19,7 +19,7 @@
 namespace Surfnet\SamlBundle\Tests\Http;
 
 use Mockery;
-use PHPUnit_Framework_TestCase as UnitTest;
+use PHPUnit\Framework\TestCase as UnitTest;
 use Surfnet\SamlBundle\Http\HttpBindingFactory;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,7 +35,7 @@ class HttpBindingFactoryTest extends UnitTest
     /** @var ParameterBag|Mockery\Mock */
     private $bag;
 
-    public function setUp()
+    public function setUp(): void
     {
         $redirectBinding = Mockery::mock('\Surfnet\SamlBundle\Http\RedirectBinding');
         $postBinding = Mockery::mock('\Surfnet\SamlBundle\Http\PostBinding');
@@ -44,7 +44,6 @@ class HttpBindingFactoryTest extends UnitTest
         $this->bag = Mockery::mock('\Symfony\Component\HttpFoundation\ParameterBag');
         $this->request->request = $this->bag;
         $this->request->query = $this->bag;
-
     }
 
     /**

--- a/src/Tests/Unit/Http/HttpBindingFactoryTest.php
+++ b/src/Tests/Unit/Http/HttpBindingFactoryTest.php
@@ -21,6 +21,7 @@ namespace Surfnet\SamlBundle\Tests\Http;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\TestCase as UnitTest;
+use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\Http\HttpBindingFactory;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -90,8 +91,6 @@ class HttpBindingFactoryTest extends MockeryTestCase
     /**
      * @test
      * @group http
-     * @expectedException \Surfnet\SamlBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Request type of "PUT" is not supported.
      */
     public function a_put_binding_can_not_be_built()
     {
@@ -99,14 +98,14 @@ class HttpBindingFactoryTest extends MockeryTestCase
             ->shouldReceive('getMethod')
             ->andReturn(Request::METHOD_PUT);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Request type of "PUT" is not supported.');
         $this->factory->build($this->request);
     }
 
     /**
      * @test
      * @group http
-     * @expectedException \Surfnet\SamlBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage POST-binding is supported for SAMLRequest.
      */
     public function an_invalid_post_authn_request_is_rejected()
     {
@@ -119,14 +118,14 @@ class HttpBindingFactoryTest extends MockeryTestCase
             ->with('SAMLRequest')
             ->andReturn(false);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('POST-binding is supported for SAMLRequest.');
         $this->factory->build($this->request);
     }
 
     /**
      * @test
      * @group http
-     * @expectedException \Surfnet\SamlBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Redirect binding is supported for SAMLRequest and Response.
      */
     public function an_invalid_get_authn_request_is_rejected()
     {
@@ -143,6 +142,8 @@ class HttpBindingFactoryTest extends MockeryTestCase
             ->with('SAMLResponse')
             ->andReturn(false);
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Redirect binding is supported for SAMLRequest and Response.');
         $this->factory->build($this->request);
     }
 }

--- a/src/Tests/Unit/Http/RedirectBindingTest.php
+++ b/src/Tests/Unit/Http/RedirectBindingTest.php
@@ -19,7 +19,7 @@
 namespace Surfnet\SamlBundle\Tests\Http;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase as UnitTest;
+use PHPUnit\Framework\TestCase as UnitTest;
 use Psr\Log\NullLogger;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Http\Exception\SignatureValidationFailedException;
@@ -48,7 +48,7 @@ MESSAGE;
      */
     private $entityRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->entityRepository = m::mock('Surfnet\SamlBundle\Entity\ServiceProviderRepository');
         $this->redirectBinding = new RedirectBinding(

--- a/src/Tests/Unit/Http/RedirectBindingTest.php
+++ b/src/Tests/Unit/Http/RedirectBindingTest.php
@@ -19,7 +19,7 @@
 namespace Surfnet\SamlBundle\Tests\Http;
 
 use Mockery as m;
-use PHPUnit\Framework\TestCase as UnitTest;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Psr\Log\NullLogger;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Http\Exception\SignatureValidationFailedException;
@@ -29,7 +29,7 @@ use Surfnet\SamlBundle\Http\RedirectBinding;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Symfony\Component\HttpFoundation\Request;
 
-class RedirectBindingTest extends UnitTest
+class RedirectBindingTest extends MockeryTestCase
 {
     const ENCODED_MESSAGE = 'fZFfa8IwFMXfBb9DyXvaJtZ1BqsURRC2Mabbw95ivc5Am3TJrXPffmmLY3%2FA15Pzuyf33On8XJXBCaxTRmeEhTEJQBdmr%2FRbRp63K3pL5rPhYOpkVdYib%2FCon%2BC9AYfDQRB4WDvRvWWksVoY6ZQTWlbgBBZik9%2FfCR7GorYGTWFK8pu6DknnwKL%2FWEetlxmR8sBHbHJDWZqOKGdsRJM0kfQAjCUJ43KX8s78ctnIz%2Blp5xpYa4dSo1fjOKGM03i8jSeCMzGevHa2%2FBK5MNo1FdgN2JMqPLmHc0b6WTmiVbsGoTf5qv66Zq2t60x0wXZ2RKydiCJXh3CWVV1CWJgqanfl0%2Bin8xutxYOvZL18NKUqPlvZR5el%2BVhYkAgZQdsA6fWVsZXE63W2itrTQ2cVaKV2CjSSqL1v9P%2FAXv4C';
     const RAW_MESSAGE = <<<MESSAGE

--- a/src/Tests/Unit/Http/RedirectBindingTest.php
+++ b/src/Tests/Unit/Http/RedirectBindingTest.php
@@ -23,11 +23,13 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Psr\Log\NullLogger;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Http\Exception\SignatureValidationFailedException;
+use Surfnet\SamlBundle\Http\Exception\UnknownServiceProviderException;
 use Surfnet\SamlBundle\Http\Exception\UnsignedRequestException;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestQueryString;
 use Surfnet\SamlBundle\Http\RedirectBinding;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class RedirectBindingTest extends MockeryTestCase
 {
@@ -61,8 +63,6 @@ MESSAGE;
     /**
      * @test
      * @group http
-     *
-     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
      */
     public function an_exception_is_thrown_when_the_request_get_parameter_is_not_set()
     {
@@ -72,19 +72,18 @@ MESSAGE;
                 ->andReturnNull()
         ->getMock();
 
+        $this->expectException(BadRequestHttpException::class);
         $this->redirectBinding->processRequest($request);
     }
 
     /**
      * @test
      * @group http
-     *
-     * @expectedException UnsignedRequestException
      */
     public function an_exception_is_thrown_when_the_request_is_signed_but_has_no_sigalg_parameter()
     {
-        $this->setExpectedException(
-            UnsignedRequestException::class,
+        $this->expectException(UnsignedRequestException::class);
+        $this->expectExceptionMessage(
             'The request includes a signature, but does not include the signature algorithm (SigAlg) parameter'
         );
 
@@ -101,6 +100,7 @@ MESSAGE;
             ->with(AuthnRequest::PARAMETER_SIGNATURE_ALGORITHM)
             ->andReturn();
 
+        $this->expectException(UnsignedRequestException::class);
         $this->redirectBinding->processRequest($request);
     }
 
@@ -112,8 +112,8 @@ MESSAGE;
      */
     public function a_signed_authn_request_cannot_be_received_from_a_request_that_is_not_a_get_request($nonGetMethod)
     {
-        $this->setExpectedException(
-            '\Symfony\Component\HttpKernel\Exception\BadRequestHttpException',
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage(
             sprintf('expected a GET method, got %s', $nonGetMethod)
         );
 
@@ -133,10 +133,8 @@ MESSAGE;
      */
     public function a_signed_authn_request_cannot_be_received_from_a_request_that_has_no_signed_saml_request()
     {
-        $this->setExpectedException(
-            UnsignedRequestException::class,
-            'The SAMLRequest is expected to be signed but it was not'
-        );
+        $this->expectException(UnsignedRequestException::class);
+        $this->expectExceptionMessage('The SAMLRequest is expected to be signed but it was not');
 
         $dummySignatureVerifier = m::mock('\Surfnet\SamlBundle\Signing\SignatureVerifier');
         $dummyEntityRepository  = m::mock('\Surfnet\SamlBundle\Entity\ServiceProviderRepository');
@@ -155,10 +153,8 @@ MESSAGE;
      */
     public function a_signed_authn_request_cannot_be_received_if_the_service_provider_in_the_authn_request_is_unknown()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\UnknownServiceProviderException',
-            'AuthnRequest received from ServiceProvider with an unknown EntityId'
-        );
+        $this->expectException(UnknownServiceProviderException::class);
+        $this->expectExceptionMessage('AuthnRequest received from ServiceProvider with an unknown EntityId');
 
         $dummySignatureVerifier = m::mock('\Surfnet\SamlBundle\Signing\SignatureVerifier');
         $mockEntityRepository   = m::mock('\Surfnet\SamlBundle\Entity\ServiceProviderRepository');
@@ -189,10 +185,8 @@ MESSAGE;
      */
     public function a_signed_authn_request_cannot_be_received_if_the_signature_is_invalid()
     {
-        $this->setExpectedException(
-            SignatureValidationFailedException::class,
-            'Validation of the signature in the AuthnRequest failed'
-        );
+        $this->expectException(SignatureValidationFailedException::class);
+        $this->expectExceptionMessage('Validation of the signature in the AuthnRequest failed');
 
         $mockSignatureVerifier = m::mock('\Surfnet\SamlBundle\Signing\SignatureVerifier');
         $mockEntityRepository  = m::mock('\Surfnet\SamlBundle\Entity\ServiceProviderRepository');
@@ -234,10 +228,8 @@ MESSAGE;
      */
     public function a_unsigned_authn_request_cannot_be_received_from_a_request_that_is_not_a_get_request($nonGetMethod)
     {
-        $this->setExpectedException(
-            '\Symfony\Component\HttpKernel\Exception\BadRequestHttpException',
-            sprintf('expected a GET method, got %s', $nonGetMethod)
-        );
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage(sprintf('expected a GET method, got %s', $nonGetMethod));
 
         $dummySignatureVerifier = m::mock('\Surfnet\SamlBundle\Signing\SignatureVerifier');
         $dummyEntityRepository  = m::mock('\Surfnet\SamlBundle\Entity\ServiceProviderRepository');
@@ -255,10 +247,8 @@ MESSAGE;
      */
     public function a_unsigned_authn_request_cannot_be_received_if_the_service_provider_in_the_authn_request_is_unknown()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\UnknownServiceProviderException',
-            'AuthnRequest received from ServiceProvider with an unknown EntityId'
-        );
+        $this->expectException(UnknownServiceProviderException::class);
+        $this->expectExceptionMessage('AuthnRequest received from ServiceProvider with an unknown EntityId');
 
         $dummySignatureVerifier = m::mock('\Surfnet\SamlBundle\Signing\SignatureVerifier');
         $dummyEntityRepository  = m::mock('\Surfnet\SamlBundle\Entity\ServiceProviderRepository');

--- a/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
+++ b/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
@@ -19,7 +19,7 @@
 namespace Surfnet\SamlBundle\Tests;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 
 final class SamlAuthenticationLoggerTest extends TestCase

--- a/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
+++ b/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
@@ -19,10 +19,11 @@
 namespace Surfnet\SamlBundle\Tests;
 
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\TestCase as TestCase;
 use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 
-final class SamlAuthenticationLoggerTest extends TestCase
+final class SamlAuthenticationLoggerTest extends MockeryTestCase
 {
     /**
      * @test

--- a/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
+++ b/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
@@ -21,6 +21,7 @@ namespace Surfnet\SamlBundle\Tests;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\TestCase as TestCase;
+use Surfnet\SamlBundle\Exception\RuntimeException;
 use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 
 final class SamlAuthenticationLoggerTest extends MockeryTestCase
@@ -42,11 +43,11 @@ final class SamlAuthenticationLoggerTest extends MockeryTestCase
 
     /**
      * @test
-     * @expectedException \Surfnet\SamlBundle\Exception\RuntimeException
      */
     public function it_throws_when_no_authentication()
     {
         $logger = new SamlAuthenticationLogger(m::mock('Psr\Log\LoggerInterface'));
+        $this->expectException(RuntimeException::class);
         $logger->emergency('message2');
     }
 }

--- a/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
@@ -18,11 +18,13 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute;
 
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\TestCase as TestCase;
+use Surfnet\SamlBundle\Exception\UnknownUrnException;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 
-class AttributeDictionaryTest extends TestCase
+class AttributeDictionaryTest extends MockeryTestCase
 {
     /**
      * @test
@@ -147,7 +149,6 @@ class AttributeDictionaryTest extends TestCase
     /**
      * @test
      * @group AttributeDictionary
-     * @expectedException \Surfnet\SamlBundle\Exception\UnknownUrnException
      */
     public function shouldThrowExceptionForUnknownAttrib()
     {
@@ -160,6 +161,8 @@ class AttributeDictionaryTest extends TestCase
         );
         $attributeDictionary = new AttributeDictionary();
         $attributeDictionary->addAttributeDefinition($existingOidAttributeDefinition);
+
+        $this->expectException(UnknownUrnException::class);
         $attributeDictionary->getAttributeDefinitionByUrn('unknown:0.0.0.0.0');
     }
 

--- a/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 

--- a/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use SAML2\Assertion;
 use stdClass;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
@@ -27,7 +27,7 @@ use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
 class ConfigurableAttributeSetFactoryTest extends TestCase
 {
     const DUMMY_ATTRIBUTE_SET_CLASS = '\Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute\Mock\DummyAttributeSet';
-    
+
     /**
      * @test
      * @group AssertionAdapter

--- a/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -21,6 +21,7 @@ namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute;
 use PHPUnit\Framework\TestCase as TestCase;
 use SAML2\Assertion;
 use stdClass;
+use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
 
@@ -69,7 +70,8 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      */
     public function the_attribute_set_to_use_can_only_be_represented_as_a_non_empty_string($nonOrEmptyString)
     {
-        $this->setExpectedException('\Surfnet\SamlBundle\Exception\InvalidArgumentException', 'non-empty string');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('non-empty string');
 
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate($nonOrEmptyString);
     }
@@ -81,7 +83,8 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      */
     public function the_attribute_set_to_use_has_to_implement_attribute_set_factory()
     {
-        $this->setExpectedException('\Surfnet\SamlBundle\Exception\InvalidArgumentException', 'implement');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('implement');
 
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate('Non\Existent\Class');
     }

--- a/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
@@ -9,6 +9,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Configuration\PrivateKey;
 use Surfnet\SamlBundle\Entity\IdentityProvider;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Http\Exception\InvalidRequestException;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,9 +19,6 @@ class AuthnRequestFactoryTest extends MockeryTestCase
     /**
      * @test
      * @group saml2
-     *
-     * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
-     * @expectedExceptionMessage Failed decoding the request, did not receive a valid base64 string
      */
     public function an_exception_is_thrown_when_a_request_is_not_properly_base64_encoded()
     {
@@ -31,15 +29,14 @@ class AuthnRequestFactoryTest extends MockeryTestCase
         ];
         $request          = new Request($queryParams, [], [], [], [], $serverParams);
 
+        $this->expectException(InvalidRequestException::class);
+        $this->expectExceptionMessage('Failed decoding the request, did not receive a valid base64 string');
         AuthnRequestFactory::createFromHttpRequest($request);
     }
 
     /**
      * @test
      * @group saml2
-     *
-     * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
-     * @expectedExceptionMessage Failed inflating the request;
      */
     public function an_exception_is_thrown_when_a_request_cannot_be_inflated()
     {
@@ -50,6 +47,8 @@ class AuthnRequestFactoryTest extends MockeryTestCase
         ];
         $request = new Request($queryParams, [], [], [], [], $serverParams);
 
+        $this->expectException(InvalidRequestException::class);
+        $this->expectExceptionMessage('Failed inflating the request;');
         AuthnRequestFactory::createFromHttpRequest($request);
     }
 

--- a/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase as UnitTest;
+use PHPUnit\Framework\TestCase as UnitTest;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Configuration\PrivateKey;
 use Surfnet\SamlBundle\Entity\IdentityProvider;

--- a/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2;
 
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\TestCase as UnitTest;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\Configuration\PrivateKey;
@@ -12,7 +13,7 @@ use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
 use Symfony\Component\HttpFoundation\Request;
 
-class AuthnRequestFactoryTest extends UnitTest
+class AuthnRequestFactoryTest extends MockeryTestCase
 {
     /**
      * @test

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -156,8 +156,8 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
 
         $authnRequest = AuthnRequest::createNew($request);
 
-        $this->assertEquals($this->nameId, $authnRequest->getNameId()->getValue());
-        $this->assertEquals($this->format, $authnRequest->getNameId()->getFormat());
+        $this->assertEquals($this->nameId, $authnRequest->getNameId());
+        $this->assertEquals($this->format, $authnRequest->getNameIdFormat());
     }
 
     /**

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2;
 
-use PHPUnit_Framework_TestCase as UnitTest;
+use PHPUnit\Framework\TestCase as UnitTest;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\DOMDocumentFactory;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -155,8 +155,8 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
 
         $authnRequest = AuthnRequest::createNew($request);
 
-        $this->assertEquals($this->nameId, $authnRequest->getNameId());
-        $this->assertEquals($this->format, $authnRequest->getNameIdFormat());
+        $this->assertEquals($this->nameId, $authnRequest->getNameId()->getValue());
+        $this->assertEquals($this->format, $authnRequest->getNameId()->getFormat());
     }
 
     /**

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -18,12 +18,13 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2;
 
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\TestCase as UnitTest;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\DOMDocumentFactory;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 
-class AuthnRequestTest extends UnitTest
+class AuthnRequestTest extends MockeryTestCase
 {
     /**
      * @var string

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
@@ -48,7 +48,8 @@ class ReceivedAuthnRequestPostTest extends TestCase
             'SAMLRequest' => base64_encode($samlRequest),
             'RelayState' => '/index.php',
         ];
-        ReceivedAuthnRequestPost::parse($parameters);
+        $parsed = ReceivedAuthnRequestPost::parse($parameters);
+        $this->assertInstanceOf(ReceivedAuthnRequestPost::class, $parsed);
     }
 
     /**

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
@@ -19,6 +19,7 @@
 namespace Tests\Unit\SAML2;
 
 use PHPUnit\Framework\TestCase as TestCase;
+use Surfnet\SamlBundle\Http\Exception\InvalidRequestException;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestPost;
 
 class ReceivedAuthnRequestPostTest extends TestCase
@@ -66,8 +67,6 @@ class ReceivedAuthnRequestPostTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
-     * @expectedExceptionMessage Failed decoding SAML request, did not receive a valid base64 string
      */
     public function it_rejects_malformed_saml_request()
     {
@@ -75,6 +74,9 @@ class ReceivedAuthnRequestPostTest extends TestCase
             'SAMLRequest' => 'this=notvalid==',
             'RelayState' => '/index.php',
         ];
+
+        $this->expectException(InvalidRequestException::class);
+        $this->expectExceptionMessage('Failed decoding SAML request, did not receive a valid base64 string');
         ReceivedAuthnRequestPost::parse($parameters);
     }
 

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
@@ -18,7 +18,7 @@
 
 namespace Tests\Unit\SAML2;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestPost;
 
 class ReceivedAuthnRequestPostTest extends TestCase

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
@@ -18,7 +18,7 @@
 
 namespace Tests\Unit\SAML2;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\DOMDocumentFactory;
 use stdClass;

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
@@ -22,6 +22,8 @@ use PHPUnit\Framework\TestCase as TestCase;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\DOMDocumentFactory;
 use stdClass;
+use Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException;
+use Surfnet\SamlBundle\Http\Exception\InvalidRequestException;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestQueryString;
 
 class ReceivedAuthnRequestQueryStringTest extends TestCase
@@ -51,10 +53,8 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_received_authn_request_query_string_cannot_be_parsed_from_non_or_empty_strings($nonOrEmptyString)
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'expected a non-empty string'
-        );
+        $this->expectException(InvalidReceivedAuthnRequestQueryStringException::class);
+        $this->expectExceptionMessage('expected a non-empty string');
 
         ReceivedAuthnRequestQueryString::parse($nonOrEmptyString);
     }
@@ -65,10 +65,8 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_received_authn_request_query_string_must_contain_valid_key_value_pairs()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'does not contain a valid key-value pair'
-        );
+        $this->expectException(InvalidReceivedAuthnRequestQueryStringException::class);
+        $this->expectExceptionMessage('does not contain a valid key-value pair');
 
         ReceivedAuthnRequestQueryString::parse('a-key-without-a-value');
     }
@@ -79,10 +77,8 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_received_authn_request_query_string_must_contain_a_base64_encoded_saml_request()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidRequestException',
-            'did not receive a valid base64 string'
-        );
+        $this->expectException(InvalidRequestException::class);
+        $this->expectExceptionMessage('did not receive a valid base64 string');
 
         $notEncodedRequest = 'non-encoded-string';
 
@@ -102,10 +98,8 @@ AUTHNREQUEST_NO_SUBJECT;
     public function a_received_authn_request_query_string_cannot_contain_a_saml_parameter_twice(
         $doubleParameterName, $queryStringWithDoubleParameter
     ) {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            sprintf('parameter "%s" already present', $doubleParameterName)
-        );
+        $this->expectException(InvalidReceivedAuthnRequestQueryStringException::class);
+        $this->expectExceptionMessage(sprintf('parameter "%s" already present', $doubleParameterName));
 
         ReceivedAuthnRequestQueryString::parse($queryStringWithDoubleParameter);
     }
@@ -116,12 +110,12 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_received_authn_request_query_string_must_contain_a_saml_request()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
+        $this->expectException(InvalidReceivedAuthnRequestQueryStringException::class);
+        $this->expectExceptionMessage(
             sprintf('parameter "%s" not found', ReceivedAuthnRequestQueryString::PARAMETER_REQUEST)
         );
 
-        $queryStringWithoutSamlRequest = 
+        $queryStringWithoutSamlRequest =
             '?' . ReceivedAuthnRequestQueryString::PARAMETER_SIGNATURE . '=' . urlencode(base64_encode('signature'))
             . '&' . ReceivedAuthnRequestQueryString::PARAMETER_SIGNATURE_ALGORITHM . '=signature-algorithm';
 
@@ -134,10 +128,8 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_received_authn_request_query_string_cannot_contain_a_signature_algorithm_without_a_signature()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'contains a signature algorithm but not a signature'
-        );
+        $this->expectException(InvalidReceivedAuthnRequestQueryStringException::class);
+        $this->expectExceptionMessage('contains a signature algorithm but not a signature');
 
         $queryStringWithSignatureAlgorithmWithoutSignature =
             '?' . ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . urlencode(base64_encode('saml-request'))
@@ -152,10 +144,8 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_received_authn_request_query_string_cannot_contain_a_signature_without_a_signature_algorithm()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'contains a signature but not a signature algorithm'
-        );
+        $this->expectException(InvalidReceivedAuthnRequestQueryStringException::class);
+        $this->expectExceptionMessage('contains a signature but not a signature algorithm');
 
         $queryStringWithSignatureWithoutSignatureAlgorithm =
             '?' . ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . urlencode(base64_encode('saml-request'))
@@ -170,10 +160,8 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_received_authn_request_query_string_cannot_contain_a_signature_that_is_not_properly_base64_encoded()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'signature is not base64 encoded correctly'
-        );
+        $this->expectException(InvalidReceivedAuthnRequestQueryStringException::class);
+        $this->expectExceptionMessage('signature is not base64 encoded correctly');
 
         $queryStringWithSignatureWithoutSignatureAlgorithm =
             '?' . ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . urlencode(base64_encode('saml-request'))
@@ -281,10 +269,8 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_saml_request_cannot_be_decoded_from_a_received_authn_request_query_string_if_it_was_not_properly_gzipped()
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidRequestException',
-            'Failed inflating SAML Request'
-        );
+        $this->expectException(InvalidRequestException::class);
+        $this->expectExceptionMessage('Failed inflating SAML Request');
 
         $notGzippedRequest = urlencode(base64_encode('this-is-not-gzipped'));
 

--- a/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
@@ -19,7 +19,7 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Response\Assertion;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;

--- a/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
@@ -19,13 +19,13 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Response\Assertion;
 
 use Mockery as m;
-use PHPUnit\Framework\TestCase as TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Response\AssertionAdapter;
 
-class AssertionAdapterTest extends TestCase
+class AssertionAdapterTest extends MockeryTestCase
 {
     /**
      * @test

--- a/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Response\Assertion;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Surfnet\SamlBundle\Exception\UnknownUrnException;
 use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
@@ -89,8 +90,6 @@ class AssertionAdapterTest extends MockeryTestCase
     /**
      * @test
      * @group AssertionAdapter
-     *
-     * @expectedException \Surfnet\SamlBundle\Exception\UnknownUrnException
      */
     public function no_presence_of_attribute_can_be_confirmed_if_no_attribute_definition_found()
     {
@@ -109,10 +108,9 @@ class AssertionAdapterTest extends MockeryTestCase
 
         // empty dictionary
         $dictionary = new AttributeDictionary();
-        $adapter      = new AssertionAdapter($assertion, $dictionary);
-        $attributeSet = $adapter->getAttributeSet();
 
-        $attributeSet->contains($attributeExpectedNotToBeContained);
+        $this->expectException(UnknownUrnException::class);
+        new AssertionAdapter($assertion, $dictionary);
     }
 
     /**

--- a/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Response\Assertion;
 
-use PHPUnit_Framework_TestCase as UnitTest;
+use PHPUnit\Framework\TestCase as UnitTest;
 use SAML2\Assertion;
 use SAML2\XML\saml\SubjectConfirmation;
 use SAML2\XML\saml\SubjectConfirmationData;

--- a/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
@@ -50,8 +50,8 @@ class InResponseToTest extends UnitTest
         $assertion                   = new Assertion();
         $subjectConfirmationWithData = new SubjectConfirmation();
         $subjectConfirmationData     = new SubjectConfirmationData();
-        $subjectConfirmationData->InResponseTo = '1';
-        $subjectConfirmationWithData->SubjectConfirmationData = $subjectConfirmationData;
+        $subjectConfirmationData->setInResponseTo('1');
+        $subjectConfirmationWithData->setSubjectConfirmationData($subjectConfirmationData);
         $assertion->setSubjectConfirmation([$subjectConfirmationWithData]);
 
         $this->assertTrue(InResponseTo::assertEquals($assertion, '1'));
@@ -71,7 +71,7 @@ class InResponseToTest extends UnitTest
 
         $assertionWithEmptyInResponseTo = new Assertion();
         $subjectConfirmationWithData = new SubjectConfirmation();
-        $subjectConfirmationWithData->SubjectConfirmationData = new SubjectConfirmationData();
+        $subjectConfirmationWithData->setSubjectConfirmationData(new SubjectConfirmationData());
         $assertionWithEmptyInResponseTo->setSubjectConfirmation([$subjectConfirmationWithData]);
 
         return [


### PR DESCRIPTION
This PR bumps the saml2 library to the latest version and bumps several dev dependencies
It also bumps the minimum required PHP-version to 7.3, which is in line with PR #115 