### PR TITLE
Allow setting ForceAuthn on AuthnRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 4.4.2
+**Feature**
+* Allow setting ForceAuthn on AuthnRequest #117
+
+# 4.4.1
+**Bugfix**
+* Support both `getMainRequest` and `getMasterRequest` when using the Symfony request stack.
+  As drafted by @epidoux in: Fix getMainRequest incompatible with symfony 4.4 #107 (thank you @epidoux)
+
 # 4.4.0
 **Feature**
 * Include SP certificate in generated metadata when present #104

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -229,12 +229,14 @@ class AuthnRequest
         return $this->request->getIsPassive();
     }
 
-    /**
-     * @return bool
-     */
-    public function isForceAuthn()
+    public function isForceAuthn(): bool
     {
         return $this->request->getForceAuthn();
+    }
+
+    public function setForceAuthn(bool $isForceAuthN): void
+    {
+        $this->request->setForceAuthn($isForceAuthN);
     }
 
     /**

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -193,6 +193,17 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
         $this->assertEquals($forceAuthn, $authnRequest->isForceAuthn());
     }
 
+    public function test_force_authn_can_be_set()
+    {
+        $domDocument = DOMDocumentFactory::fromString($this->authRequestIsPassiveFalseAndNoForceAuthnFalse);
+        $request     = new SAML2AuthnRequest($domDocument->documentElement);
+        $authnRequest = AuthnRequest::createNew($request);
+
+        $this->assertFalse($authnRequest->isForceAuthn());
+        $authnRequest->setForceAuthn(true);
+        $this->assertTrue($authnRequest->isForceAuthn());
+    }
+
     public function provideIsPassiveAndForceAuthnCombinations()
     {
         return [


### PR DESCRIPTION
When using the proxy AuthnRequest (creating a AR value object from XML) you get to reset several properties of the parsed request. But not the force authn flag. That changed in this PR. You can now modify the ForceAuthn flag.

A test was added to verify this behavior.

This PR is targeted for release with version 4.4.2