### PR TITLE
Add a SAML Authenticator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/
 .idea
 composer.lock
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ language: php
 
 matrix:
   include:
-    - php: 7.3
     - php: 7.4
     - php: 8.0
     - php: 8.1
+    - php: 8.2
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ dist: jammy
 
 matrix:
   include:
+    - php: 8.0
     - php: 8.1
     - php: 8.2
   allow_failures:
+    - php: 8.0
     - php: 8.2
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ language: php
 
 matrix:
   include:
-    - php: 7.4
-    - php: 8.0
     - php: 8.1
     - php: 8.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,13 @@
 
 language: php
 
+dist: jammy
+
 matrix:
   include:
     - php: 8.1
+    - php: 8.2
+  allow_failures:
     - php: 8.2
 
 env:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ providers keep in mind that you need to assign `surfnet_saml.remote.service_prov
 
 ## Example Usage
 
+### Symfony Authentication
+As of version 5 of this bundle, we started supporting SAML authentications via the Stepup SAML bundle. This ties into 
+the Symfony Security component. 
+
+Details about how to install this into your SP, see the [EXAMPLES.md](EXAMPLES.md).
+
 ### Metadata Publishing
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,13 @@
         "php": ">=7.3|^8.0",
         "ext-dom": "*",
         "ext-openssl": "*",
-        "robrichards/xmlseclibs": "^3.0.4",
-        "simplesamlphp/saml2": "3.2.*",
-        "symfony/dependency-injection": "^4.4|^5.0",
-        "symfony/framework-bundle": "^4.4|^5.0",
-        "symfony/templating": "^4.4|^5.0",
-        "twig/twig": "^2"
+        "robrichards/xmlseclibs": "^3.1.1",
+        "simplesamlphp/saml2": "^4.6.4",
+        "symfony/dependency-injection": "5.4.*",
+        "symfony/framework-bundle": "5.4.*",
+        "symfony/security-bundle": "5.4.*",
+        "symfony/templating": "5.4.*",
+        "twig/twig": "^2|^3"
     },
     "require-dev": {
         "jasny/phpunit-xsdvalidation": "^1.0",
@@ -22,10 +23,10 @@
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "^9.5",
         "psr/log": "~1.0",
-        "sebastian/exporter": "^4.0",
-        "sebastian/phpcpd": "^2.0",
-        "squizlabs/php_codesniffer": "^3.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0"
+        "sebastian/exporter": "^4.0.5",
+        "sebastian/phpcpd": "^6.0",
+        "squizlabs/php_codesniffer": "^3.7.1",
+        "symfony/phpunit-bridge": "5.4.*"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.3|^8.0",
+        "php": "^8.0",
         "ext-dom": "*",
         "ext-openssl": "*",
         "robrichards/xmlseclibs": "^3.1.1",
-        "simplesamlphp/saml2": "^4.6.4",
+        "simplesamlphp/saml2": "^4.6",
         "symfony/dependency-injection": "5.4.*",
         "symfony/framework-bundle": "5.4.*",
         "symfony/security-bundle": "5.4.*",
@@ -18,8 +18,9 @@
         "twig/twig": "^2|^3"
     },
     "require-dev": {
-        "jasny/phpunit-xsdvalidation": "^1.0",
-        "mockery/mockery": "~0.9",
+        "ext-zlib": "*",
+        "mbhsoft/phpunit-xsdvalidation": "^3.0",
+        "mockery/mockery": "^1.5",
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "^9.5",
         "psr/log": "~1.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,8 +8,10 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="src/Tests/Bootstrap.php">
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
     <testsuites>
         <testsuite name="Unit">
             <directory>src/Tests/Unit</directory>
@@ -18,14 +20,6 @@
             <directory>src/Tests/Component</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory>src</directory>
-            <exclude>
-                <directory>src/Tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
     <listeners>
         <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
         <listener class="\Mockery\Adapter\Phpunit\TestListener"/>

--- a/src/Http/HttpBinding.php
+++ b/src/Http/HttpBinding.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2017 SURFnet bv
@@ -20,15 +20,9 @@ namespace Surfnet\SamlBundle\Http;
 
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * Interface HttpBinding
- *
- *
- *
- * @package Surfnet\SamlBundle\Http
- */
 interface HttpBinding
 {
     /**
@@ -36,7 +30,7 @@ interface HttpBinding
      *
      * @return ReceivedAuthnRequest
      */
-    public function receiveSignedAuthnRequestFrom(Request $request);
+    public function receiveSignedAuthnRequestFrom(Request $request): AuthnRequest;
 
-    public function createResponseFor(AuthnRequest $request);
+    public function createResponseFor(AuthnRequest $request): RedirectResponse;
 }

--- a/src/Http/PostBinding.php
+++ b/src/Http/PostBinding.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -19,7 +19,6 @@
 namespace Surfnet\SamlBundle\Http;
 
 use LogicException;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 use SAML2\Assertion;
 use SAML2\Certificate\KeyLoader;
@@ -39,6 +38,7 @@ use Surfnet\SamlBundle\Http\Exception\UnknownServiceProviderException;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest;
 use Surfnet\SamlBundle\Signing\SignatureVerifier;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -47,43 +47,23 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  */
 class PostBinding implements HttpBinding
 {
-    /**
-     * @var Processor
-     */
-    private $responseProcessor;
+    private Processor $responseProcessor;
 
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private $logger;
+    private KeyLoader $signatureVerifier;
 
-    /**
-     * @var KeyLoader
-     */
-    private $signatureVerifier;
-
-    /**
-     * @var \Surfnet\SamlBundle\Entity\ServiceProviderRepository
-     */
-    private $entityRepository;
+    private ?ServiceProviderRepository $entityRepository;
 
     public function __construct(
         Processor $responseProcessor,
-        LoggerInterface $logger,
         SignatureVerifier $signatureVerifier,
         ServiceProviderRepository $repository = null
     ) {
         $this->responseProcessor = $responseProcessor;
-        $this->logger = $logger;
         $this->signatureVerifier = $signatureVerifier;
         $this->entityRepository = $repository;
     }
 
     /**
-     * @param Request $request
-     * @param IdentityProvider $identityProvider
-     * @param ServiceProvider $serviceProvider
-     * @return Assertion
      * @throws AuthnFailedSamlResponseException
      * @throws NoAuthnContextSamlResponseException
      * @throws PreconditionNotMetException
@@ -92,7 +72,7 @@ class PostBinding implements HttpBinding
         Request $request,
         IdentityProvider $identityProvider,
         ServiceProvider $serviceProvider
-    ) {
+    ): Assertion {
         $response = $request->request->get('SAMLResponse');
         if (!$response) {
             throw new BadRequestHttpException('Response must include a SAMLResponse, none found');
@@ -128,7 +108,7 @@ class PostBinding implements HttpBinding
         return $assertions->getOnlyElement();
     }
 
-    public function receiveSignedAuthnRequestFrom(Request $request)
+    public function receiveSignedAuthnRequestFrom(Request $request): AuthnRequest
     {
         if (!$this->entityRepository) {
             throw new LogicException(
@@ -176,16 +156,12 @@ class PostBinding implements HttpBinding
         return $authnRequest;
     }
 
-    /**
-     * @param Request $request
-     * @return string
-     */
-    private function getFullRequestUri(Request $request)
+    private function getFullRequestUri(Request $request): string
     {
         return $request->getSchemeAndHttpHost() . $request->getBasePath() . $request->getRequestUri();
     }
 
-    public function createResponseFor(AuthnRequest $request)
+    public function createResponseFor(AuthnRequest $request): RedirectResponse
     {
         throw new RuntimeException(
             'Not implemented: caller should implement the response for POST binding'

--- a/src/Http/PostBinding.php
+++ b/src/Http/PostBinding.php
@@ -21,7 +21,6 @@ namespace Surfnet\SamlBundle\Http;
 use LogicException;
 use RuntimeException;
 use SAML2\Assertion;
-use SAML2\Certificate\KeyLoader;
 use SAML2\Configuration\Destination;
 use SAML2\Constants;
 use SAML2\DOMDocumentFactory;
@@ -49,7 +48,7 @@ class PostBinding implements HttpBinding
 {
     private Processor $responseProcessor;
 
-    private KeyLoader $signatureVerifier;
+    private SignatureVerifier $signatureVerifier;
 
     private ?ServiceProviderRepository $entityRepository;
 

--- a/src/Http/PostBinding.php
+++ b/src/Http/PostBinding.php
@@ -100,9 +100,7 @@ class PostBinding implements HttpBinding
 
         $response = base64_decode($response);
 
-        $previous = libxml_disable_entity_loader(true);
         $asXml    = DOMDocumentFactory::fromString($response);
-        libxml_disable_entity_loader($previous);
 
         try {
             $assertions = $this->responseProcessor->process(

--- a/src/Http/ReceivedAuthnRequestQueryString.php
+++ b/src/Http/ReceivedAuthnRequestQueryString.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2017 SURFnet B.V.
@@ -26,37 +26,25 @@ use Surfnet\SamlBundle\Http\Exception\InvalidRequestException;
 
 final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
 {
-    const PARAMETER_REQUEST = 'SAMLRequest';
-    const PARAMETER_SIGNATURE = 'Signature';
-    const PARAMETER_SIGNATURE_ALGORITHM = 'SigAlg';
-    const PARAMETER_RELAY_STATE = 'RelayState';
+    public const PARAMETER_REQUEST = 'SAMLRequest';
+    public const PARAMETER_SIGNATURE = 'Signature';
+    public const PARAMETER_SIGNATURE_ALGORITHM = 'SigAlg';
+    public const PARAMETER_RELAY_STATE = 'RelayState';
 
-    private static $samlParameters = [
+    private static array $samlParameters = [
         self::PARAMETER_REQUEST,
         self::PARAMETER_SIGNATURE,
         self::PARAMETER_SIGNATURE_ALGORITHM,
         self::PARAMETER_RELAY_STATE,
     ];
 
-    /**
-     * @var string
-     */
-    private $samlRequest;
+    private string $samlRequest;
 
-    /**
-     * @var string|null
-     */
-    private $signature;
+    private ?string $signature = null;
 
-    /**
-     * @var string|null
-     */
-    private $signatureAlgorithm;
+    private ?string $signatureAlgorithm = null;
 
-    /**
-     * @var string|null
-     */
-    private $relayState;
+    private ?string $relayState = null;
 
     private function __construct($samlRequest)
     {
@@ -64,21 +52,11 @@ final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
     }
 
     /**
-     * @param string $query
-     * @return ReceivedAuthnRequestQueryString
-     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Extensive validation
      * @SuppressWarnings(PHPMD.NPathComplexity) Extensive validation
      */
-    public static function parse($query)
+    public static function parse(string $query): ReceivedAuthnRequestQueryString
     {
-        if (!is_string($query)) {
-            throw new InvalidReceivedAuthnRequestQueryStringException(sprintf(
-                'Could not parse query string: expected a non-empty string, %s given',
-                is_object($query) ? get_class($query) : gettype($query)
-            ));
-        }
-
         $queryWithoutSeparator = ltrim($query, '?');
 
         if (strlen($queryWithoutSeparator) <= strlen('SAMLRequest=')) {
@@ -165,18 +143,12 @@ final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
         return $parsedQueryString;
     }
 
-    /**
-     * @return bool
-     */
-    public function hasRelayState()
+    public function hasRelayState(): bool
     {
         return $this->relayState !== null;
     }
 
-    /**
-     * @return string
-     */
-    public function getSignedQueryString()
+    public function getSignedQueryString(): string
     {
         if (!$this->isSigned()) {
             throw new LogicException(
@@ -195,10 +167,7 @@ final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
         return $query;
     }
 
-    /**
-     * @return string
-     */
-    public function getDecodedSamlRequest()
+    public function getDecodedSamlRequest(): string
     {
         $samlRequest = base64_decode(urldecode($this->samlRequest), true);
 
@@ -222,10 +191,7 @@ final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
         return $samlRequest;
     }
 
-    /**
-     * @return string
-     */
-    public function getDecodedSignature()
+    public function getDecodedSignature(): string
     {
         if (!$this->isSigned()) {
             throw new RuntimeException('Cannot decode signature: SAMLRequest is not signed');
@@ -234,59 +200,37 @@ final class ReceivedAuthnRequestQueryString implements SignatureVerifiable
         return base64_decode(urldecode($this->signature), true);
     }
 
-    /**
-     * @return null|string
-     */
-    public function getSignature()
+    public function getSignature(): ?string
     {
         return $this->signature;
     }
 
-    /**
-     * @return bool
-     */
     public function isSigned()
     {
         return $this->signature !== null && $this->signatureAlgorithm !== null;
     }
 
-    /**
-     * @return string
-     */
-    public function getSamlRequest()
+    public function getSamlRequest(): string
     {
         return $this->samlRequest;
     }
 
-    /**
-     * @return null|string
-     */
-    public function getSignatureAlgorithm()
+    public function getSignatureAlgorithm(): ?string
     {
         return urldecode($this->signatureAlgorithm);
     }
 
-    /**
-     * @return null|string
-     */
-    public function getRelayState()
+    public function getRelayState(): ?string
     {
         return $this->relayState;
     }
 
-    /**
-     * @return string
-     */
-    public function getSignedRequestPayload()
+    public function getSignedRequestPayload(): string
     {
         return $this->getSignedQueryString();
     }
 
-    /**
-     * @param XMLSecurityKey $key
-     * @return bool
-     */
-    public function verify(XMLSecurityKey $key)
+    public function verify(XMLSecurityKey $key): bool
     {
         $isVerified = $key->verifySignature($this->getSignedRequestPayload(), $this->getDecodedSignature());
         if ($isVerified !== 1) {

--- a/src/Http/RedirectBinding.php
+++ b/src/Http/RedirectBinding.php
@@ -43,7 +43,7 @@ class RedirectBinding implements HttpBinding
 {
     private SignatureVerifier $signatureVerifier;
 
-    private ServiceProviderRepository $entityRepository;
+    private ?ServiceProviderRepository $entityRepository;
 
     public function __construct(
         SignatureVerifier $signatureVerifier,

--- a/src/Http/RedirectBinding.php
+++ b/src/Http/RedirectBinding.php
@@ -20,6 +20,7 @@ namespace Surfnet\SamlBundle\Http;
 
 use Psr\Log\LoggerInterface;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Certificate\KeyLoader;
 use Surfnet\SamlBundle\Entity\ServiceProviderRepository;
 use Surfnet\SamlBundle\Exception\LogicException;
 use Surfnet\SamlBundle\Http\Exception\SignatureValidationFailedException;
@@ -40,36 +41,19 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  */
 class RedirectBinding implements HttpBinding
 {
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private $logger;
+    private SignatureVerifier $signatureVerifier;
 
-    /**
-     * @var \SAML2\Certificate\KeyLoader
-     */
-    private $signatureVerifier;
-
-    /**
-     * @var \Surfnet\SamlBundle\Entity\ServiceProviderRepository
-     */
-    private $entityRepository;
+    private ServiceProviderRepository $entityRepository;
 
     public function __construct(
-        LoggerInterface $logger,
         SignatureVerifier $signatureVerifier,
         ServiceProviderRepository $repository = null
     ) {
-        $this->logger = $logger;
         $this->signatureVerifier = $signatureVerifier;
         $this->entityRepository = $repository;
     }
 
-    /**
-     * @param Request $request
-     * @return AuthnRequest
-     */
-    public function processUnsignedRequest(Request $request)
+    public function processUnsignedRequest(Request $request): AuthnRequest
     {
         if (!$this->entityRepository) {
             throw new LogicException(
@@ -104,11 +88,7 @@ class RedirectBinding implements HttpBinding
         return $authnRequest;
     }
 
-    /**
-     * @param Request $request
-     * @return AuthnRequest
-     */
-    public function processSignedRequest(Request $request)
+    public function processSignedRequest(Request $request): AuthnRequest
     {
         if (!$this->entityRepository) {
             throw new LogicException(
@@ -149,11 +129,7 @@ class RedirectBinding implements HttpBinding
         return $authnRequest;
     }
 
-    /**
-     * @param Request $request
-     * @return ReceivedAuthnRequest
-     */
-    public function receiveUnsignedAuthnRequestFrom(Request $request)
+    public function receiveUnsignedAuthnRequestFrom(Request $request): AuthnRequest
     {
         if (!$this->entityRepository) {
             throw new LogicException(
@@ -197,12 +173,9 @@ class RedirectBinding implements HttpBinding
     }
 
     /**
-     * @param Request $request
-     * @return ReceivedAuthnRequest
-     *
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function receiveSignedAuthnRequestFrom(Request $request)
+    public function receiveSignedAuthnRequestFrom(Request $request): AuthnRequest
     {
         if (!$this->entityRepository) {
             throw new LogicException(
@@ -265,25 +238,19 @@ class RedirectBinding implements HttpBinding
     }
 
     /**
-     * @param Request $request
-     * @return AuthnRequest
      * @throws \Exception
      *
      * @deprecated Use receiveSignedAuthnRequestFrom or receiveUnsignedAuthnRequestFrom
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function processRequest(Request $request)
+    public function processRequest(Request $request): AuthnRequest
     {
         return $this->processSignedRequest($request);
     }
 
     /**
      * @deprecated Please use the `createResponseFor` method instead
-     * @param AuthnRequest $request
-     * @return RedirectResponse
      */
-    public function createRedirectResponseFor(AuthnRequest $request)
+    public function createRedirectResponseFor(AuthnRequest $request): RedirectResponse
     {
         return new RedirectResponse($request->getDestination() . '?' . $request->buildRequestQuery());
     }
@@ -321,7 +288,7 @@ class RedirectBinding implements HttpBinding
      * @param Request $request
      * @return string
      */
-    private function getFullRequestUri(Request $request)
+    private function getFullRequestUri(Request $request): string
     {
         return $request->getSchemeAndHttpHost() . $request->getBasePath() . $request->getRequestUri();
     }
@@ -330,7 +297,7 @@ class RedirectBinding implements HttpBinding
      * @param AuthnRequest $request
      * @return RedirectResponse
      */
-    public function createResponseFor(AuthnRequest $request)
+    public function createResponseFor(AuthnRequest $request): RedirectResponse
     {
         return $this->createRedirectResponseFor($request);
     }

--- a/src/Monolog/SamlAuthenticationLogger.php
+++ b/src/Monolog/SamlAuthenticationLogger.php
@@ -19,7 +19,6 @@
 namespace Surfnet\SamlBundle\Monolog;
 
 use Psr\Log\LoggerInterface;
-use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\Exception\RuntimeException;
 
 /**
@@ -29,15 +28,9 @@ use Surfnet\SamlBundle\Exception\RuntimeException;
  */
 final class SamlAuthenticationLogger implements LoggerInterface
 {
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
-    /**
-     * @var string|null
-     */
-    private $sari;
+    private ?string $sari;
 
     public function __construct(LoggerInterface $logger)
     {
@@ -46,72 +39,64 @@ final class SamlAuthenticationLogger implements LoggerInterface
 
     /**
      * @param string $requestId The SAML authentication request ID of the initial request (not subsequent proxy requests).
-     * @return self
      */
-    public function forAuthentication($requestId)
+    public function forAuthentication(string $requestId): self
     {
-        if (!is_string($requestId)) {
-            throw InvalidArgumentException::invalidType('string', 'requestId', $requestId);
-        }
-
         $logger = new self($this->logger);
         $logger->sari = $requestId;
 
         return $logger;
     }
 
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
         $this->logger->emergency($message, $this->modifyContext($context));
     }
 
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
         $this->logger->alert($message, $this->modifyContext($context));
     }
 
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
         $this->logger->critical($message, $this->modifyContext($context));
     }
 
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
         $this->logger->error($message, $this->modifyContext($context));
     }
 
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
         $this->logger->warning($message, $this->modifyContext($context));
     }
 
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
         $this->logger->notice($message, $this->modifyContext($context));
     }
 
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
         $this->logger->info($message, $this->modifyContext($context));
     }
 
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
         $this->logger->debug($message, $this->modifyContext($context));
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->logger->log($level, $message, $this->modifyContext($context));
     }
 
     /**
-     * Adds the SARI to the log context.
-     *
-     * @param array $context
-     * @return array
+     * Adds the SARI to the log context
      */
-    private function modifyContext(array $context)
+    private function modifyContext(array $context): array
     {
         if (!$this->sari) {
             throw new RuntimeException('Authentication logging context is unknown');

--- a/src/Monolog/SamlAuthenticationLogger.php
+++ b/src/Monolog/SamlAuthenticationLogger.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 
 /**
  * Copyright 2014 SURFnet bv

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -56,7 +56,6 @@ services:
     surfnet_saml.http.redirect_binding:
         class: Surfnet\SamlBundle\Http\RedirectBinding
         arguments:
-            - '@logger'
             - '@surfnet_saml.signing.signature_verifier'
             - '@?surfnet_saml.entity.entity_repository'
 
@@ -67,7 +66,6 @@ services:
         class: Surfnet\SamlBundle\Http\PostBinding
         arguments:
             - '@surfnet_saml.saml2.response_processor'
-            - '@logger'
             - '@surfnet_saml.signing.signature_verifier'
             - '@?surfnet_saml.entity.entity_repository'
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -144,3 +144,48 @@ services:
 
     Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger:
         alias: surfnet_saml.logger
+
+    Surfnet\SamlBundle\Security\Authentication\Handler\ProcessSamlAuthenticationHandler:
+        arguments:
+            - '@Surfnet\SamlBundle\Security\Authentication\SamlInteractionProvider'
+            - '@Surfnet\SamlBundle\Security\Authentication\Session\SessionStorage'
+            - '@surfnet_saml.logger'
+
+    Surfnet\SamlBundle\Security\Authentication\SamlInteractionProvider:
+        arguments:
+            - '@surfnet_saml.hosted.service_provider'
+            - '@surfnet_saml.remote.idp'
+            - '@surfnet_saml.http.redirect_binding'
+            - '@surfnet_saml.http.post_binding'
+            - '@Surfnet\SamlBundle\Security\Authentication\Session\SessionStorage'
+
+    Surfnet\SamlBundle\Security\Authentication\Handler\SuccessHandler:
+        arguments:
+            - '@security.http_utils'
+            - []
+            - '@logger'
+
+    Surfnet\SamlBundle\Security\Authentication\Handler\FailureHandler:
+        arguments:
+            - '@kernel'
+            - '@security.http_utils'
+            - [ ]
+            - '@logger'
+
+    Surfnet\SamlBundle\Security\Authentication\SamlAuthenticator:
+        arguments:
+            - '@surfnet_saml.remote.idp'
+            - '@surfnet_saml.hosted.service_provider'
+            - '@surfnet_saml.http.redirect_binding'
+            - '@Surfnet\SamlBundle\Security\Authentication\Session\SessionStorage'
+            - '@Surfnet\SamlBundle\Security\Authentication\Handler\ProcessSamlAuthenticationHandler'
+            - '@Surfnet\SamlBundle\Security\Authentication\Handler\SuccessHandler'
+            - '@Surfnet\SamlBundle\Security\Authentication\Handler\FailureHandler'
+            - '@surfnet_saml.saml_provider'
+            - '@router'
+            - '@logger'
+            - '%env(acs_location_route_name)%'
+
+    Surfnet\SamlBundle\Security\Authentication\Session\SessionStorage:
+        arguments:
+            - '@session'

--- a/src/SAML2/Attribute/AttributeSet.php
+++ b/src/SAML2/Attribute/AttributeSet.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2015 SURFnet B.V.

--- a/src/SAML2/Attribute/AttributeSet.php
+++ b/src/SAML2/Attribute/AttributeSet.php
@@ -23,15 +23,16 @@ use SAML2\Assertion;
 use Surfnet\SamlBundle\Exception\RuntimeException;
 use Surfnet\SamlBundle\Exception\UnknownUrnException;
 use Surfnet\SamlBundle\SAML2\Attribute\Filter\AttributeFilter;
+use Traversable;
 
 class AttributeSet implements AttributeSetFactory, AttributeSetInterface
 {
     /**
      * @var Attribute[]
      */
-    private $attributes = [];
+    private array $attributes = [];
 
-    public static function createFrom(Assertion $assertion, AttributeDictionary $attributeDictionary)
+    public static function createFrom(Assertion $assertion, AttributeDictionary $attributeDictionary): AttributeSet
     {
         $attributeSet = new AttributeSet();
 
@@ -52,7 +53,7 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
         return $attributeSet;
     }
 
-    public static function create(array $attributes)
+    public static function create(array $attributes): AttributeSet
     {
         $attributeSet = new AttributeSet();
 
@@ -67,12 +68,12 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
     {
     }
 
-    public function apply(AttributeFilter $attributeFilter)
+    public function apply(AttributeFilter $attributeFilter): AttributeSet
     {
         return self::create(array_filter($this->attributes, [$attributeFilter, 'allows']));
     }
 
-    public function getAttributeByDefinition(AttributeDefinition $attributeDefinition)
+    public function getAttributeByDefinition(AttributeDefinition $attributeDefinition): Attribute
     {
         foreach ($this->attributes as $attribute) {
             if ($attributeDefinition->equals($attribute->getAttributeDefinition())) {
@@ -86,7 +87,7 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
         ));
     }
 
-    public function containsAttributeDefinedBy(AttributeDefinition $attributeDefinition)
+    public function containsAttributeDefinedBy(AttributeDefinition $attributeDefinition): bool
     {
         foreach ($this->attributes as $attribute) {
             if ($attributeDefinition->equals($attribute->getAttributeDefinition())) {
@@ -97,7 +98,7 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
         return false;
     }
 
-    public function contains(Attribute $otherAttribute)
+    public function contains(Attribute $otherAttribute): bool
     {
         foreach ($this->attributes as $attribute) {
             if ($attribute->equals($otherAttribute)) {
@@ -108,22 +109,20 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
         return false;
     }
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->attributes);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->attributes);
     }
 
     /**
-     * @param Attribute $attribute
-     *
      * @SuppressWarnings(PHPMD.UnusedPrivateMethod) PHPMD does not see that this is being called in our static method
      */
-    protected function initializeWith(Attribute $attribute)
+    protected function initializeWith(Attribute $attribute): void
     {
         if ($this->contains($attribute)) {
             return;

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -21,6 +21,7 @@ namespace Surfnet\SamlBundle\SAML2;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\Constants;
+use SAML2\XML\saml\NameID;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\SAML2\Extensions\ExtensionsMapperTrait;
 
@@ -170,11 +171,11 @@ class AuthnRequest
     {
         $nameId = $this->request->getNameId();
 
-        if (!isset($nameId->value)) {
+        if (!$nameId->getValue()) {
             return;
         }
 
-        return $nameId->value;
+        return $nameId->getValue();
     }
 
     /**
@@ -184,33 +185,24 @@ class AuthnRequest
     {
         $nameId = $this->request->getNameId();
 
-        if (!isset($nameId->Format)) {
+        if (!$nameId->getFormat()) {
             return;
         }
 
-        return $nameId->Format;
+        return $nameId->getFormat();
     }
 
     /**
      * @param string      $nameId
      * @param string|null $format
      */
-    public function setSubject($nameId, $format = null)
+    public function setSubject(string $nameId, ?string $format = null)
     {
-        if (!is_string($nameId)) {
-            throw InvalidArgumentException::invalidType('string', 'nameId', $nameId);
-        }
+        $nameIdVo = new NameID();
+        $nameIdVo->setValue($nameId);
+        $nameIdVo->setFormat(($format ?: Constants::NAMEID_UNSPECIFIED));
 
-        if (!is_null($format) && !is_string($format)) {
-            throw InvalidArgumentException::invalidType('string', 'format', $format);
-        }
-
-        $nameId = [
-            'Value' => $nameId,
-            'Format' => ($format ?: Constants::NAMEID_UNSPECIFIED)
-        ];
-
-        $this->request->setNameId($nameId);
+        $this->request->setNameId($nameIdVo);
     }
 
     /**

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -109,9 +109,7 @@ class AuthnRequestFactory
         }
 
         // additional security against XXE Processing vulnerability
-        $previous = libxml_disable_entity_loader(true);
         $document = DOMDocumentFactory::fromString($samlRequest);
-        libxml_disable_entity_loader($previous);
 
         $request = Message::fromXML($document->firstChild);
 

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -25,6 +25,7 @@ use SAML2\Configuration\PrivateKey;
 use SAML2\Constants;
 use SAML2\DOMDocumentFactory;
 use SAML2\Message;
+use SAML2\XML\saml\Issuer;
 use Surfnet\SamlBundle\Entity\IdentityProvider;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Exception\RuntimeException;
@@ -135,10 +136,12 @@ class AuthnRequestFactory
         IdentityProvider $identityProvider,
         $forceAuthn = false
     ) {
+        $issuer = new Issuer();
+        $issuer->setValue($serviceProvider->getEntityId());
         $request = new SAML2AuthnRequest();
         $request->setAssertionConsumerServiceURL($serviceProvider->getAssertionConsumerUrl());
         $request->setDestination($identityProvider->getSsoUrl());
-        $request->setIssuer($serviceProvider->getEntityId());
+        $request->setIssuer($issuer);
         $request->setProtocolBinding(Constants::BINDING_HTTP_POST);
         $request->setForceAuthn($forceAuthn);
         $request->setSignatureKey(self::loadPrivateKey(

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -37,12 +37,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class AuthnRequestFactory
 {
-    /**
-     * @deprecated use ReceivedAuthnRequest::from()
-     * @param Request $httpRequest
-     * @return AuthnRequest
-     */
-    public static function createUnsignedFromHttpRequest(Request $httpRequest)
+    public static function createUnsignedFromHttpRequest(Request $httpRequest): AuthnRequest
     {
         return AuthnRequest::createUnsigned(
             self::createAuthnRequestFromHttpRequest($httpRequest),
@@ -53,10 +48,8 @@ class AuthnRequestFactory
 
     /**
      * @deprecated use ReceivedAuthnRequest::from()
-     * @param Request $httpRequest
-     * @return AuthnRequest
      */
-    public static function createSignedFromHttpRequest(Request $httpRequest)
+    public static function createSignedFromHttpRequest(Request $httpRequest): AuthnRequest
     {
         return AuthnRequest::createSigned(
             self::createAuthnRequestFromHttpRequest($httpRequest),
@@ -69,22 +62,18 @@ class AuthnRequestFactory
 
     /**
      * @deprecated use createSignedFromHttpRequest or createUnsignedFromHttpRequest
-     * @param Request $httpRequest
-     * @return AuthnRequest
      */
-    public static function createFromHttpRequest(Request $httpRequest)
+    public static function createFromHttpRequest(Request $httpRequest): AuthnRequest
     {
         return static::createSignedFromHttpRequest($httpRequest);
     }
 
     /**
-     * @param Request $httpRequest
-     * @return SAML2AuthnRequest
      * @throws \Exception
      */
     private static function createAuthnRequestFromHttpRequest(
         Request $httpRequest
-    ) {
+    ): SAML2AuthnRequest {
         // the GET parameter is already urldecoded by Symfony, so we should not do it again.
         $samlRequest = base64_decode($httpRequest->get(AuthnRequest::PARAMETER_REQUEST), true);
         if ($samlRequest === false) {
@@ -116,24 +105,18 @@ class AuthnRequestFactory
         if (!$request instanceof SAML2AuthnRequest) {
             throw new RuntimeException(sprintf(
                 'The received request is not an AuthnRequest, "%s" received instead',
-                substr(get_class($request), strrpos($request, '_') + 1)
+                get_class($request)
             ));
         }
 
         return $request;
     }
 
-    /**
-     * @param ServiceProvider  $serviceProvider
-     * @param IdentityProvider $identityProvider
-     * @param bool $forceAuthn
-     * @return AuthnRequest
-     */
     public static function createNewRequest(
         ServiceProvider $serviceProvider,
         IdentityProvider $identityProvider,
-        $forceAuthn = false
-    ) {
+        bool $forceAuthn = false
+    ): AuthnRequest {
         $issuer = new Issuer();
         $issuer->setValue($serviceProvider->getEntityId());
         $request = new SAML2AuthnRequest();
@@ -149,11 +132,7 @@ class AuthnRequestFactory
         return AuthnRequest::createNew($request);
     }
 
-    /**
-     * @param PrivateKey $key
-     * @return PrivateKey|XMLSecurityKey
-     */
-    private static function loadPrivateKey(PrivateKey $key)
+    private static function loadPrivateKey(PrivateKey $key): XMLSecurityKey
     {
         $keyLoader = new PrivateKeyLoader();
         $privateKey = $keyLoader->loadPrivateKey($key);

--- a/src/SAML2/BridgeContainer.php
+++ b/src/SAML2/BridgeContainer.php
@@ -41,7 +41,7 @@ class BridgeContainer extends AbstractContainer
     /**
      * @return LoggerInterface
      */
-    public function getLogger()
+    public function getLogger(): LoggerInterface
     {
         return $this->logger;
     }
@@ -49,12 +49,12 @@ class BridgeContainer extends AbstractContainer
     /**
      * Generate a random identifier for identifying SAML2 documents.
      */
-    public function generateId()
+    public function generateId(): string
     {
         return '_' . bin2hex(openssl_random_pseudo_bytes(30));
     }
 
-    public function debugMessage($message, $type)
+    public function debugMessage($message, $type): void
     {
         if ($message instanceof \DOMElement) {
             $message = $message->ownerDocument->saveXML($message);
@@ -63,19 +63,37 @@ class BridgeContainer extends AbstractContainer
         $this->logger->debug($message, ['type' => $type]);
     }
 
-    public function redirect($url, $data = array())
+    public function redirect($url, $data = array()): void
     {
         throw new BadMethodCallException(sprintf(
-            "%s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
+            "%s:%s may not be called in the Surfnet\\SamlBundle",
             __CLASS__,
             __METHOD__
         ));
     }
 
-    public function postRedirect($url, $data = array())
+    public function postRedirect($url, $data = array()): void
     {
         throw new BadMethodCallException(sprintf(
-            "%s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
+            "%s:%s may not be called in the Surfnet\\SamlBundle",
+            __CLASS__,
+            __METHOD__
+        ));
+    }
+
+    public function getTempDir(): string
+    {
+        throw new BadMethodCallException(sprintf(
+            "%s:%s may not be called in the Surfnet\\SamlBundle",
+            __CLASS__,
+            __METHOD__
+        ));
+    }
+
+    public function writeFile(string $filename, string $data, int $mode = null): void
+    {
+        throw new BadMethodCallException(sprintf(
+            "%s:%s may not be called in the Surfnet\\SamlBundle",
             __CLASS__,
             __METHOD__
         ));

--- a/src/SAML2/Extensions/ExtensionsMapperTrait.php
+++ b/src/SAML2/Extensions/ExtensionsMapperTrait.php
@@ -1,4 +1,20 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2021 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace Surfnet\SamlBundle\SAML2\Extensions;
 
@@ -6,13 +22,9 @@ use SAML2\XML\Chunk as SAML2Chunk;
 
 trait ExtensionsMapperTrait
 {
+    private Extensions $extensions;
 
-    /**
-     * @var Extensions
-     */
-    private $extensions;
-
-    private function loadExtensionsFromSaml2AuthNRequest()
+    private function loadExtensionsFromSaml2AuthNRequest(): void
     {
         $this->extensions = new Extensions();
         if (!empty($this->request->getExtensions())) {
@@ -46,7 +58,7 @@ trait ExtensionsMapperTrait
         return $this->extensions;
     }
 
-    public function setExtensions(Extensions $extensions)
+    public function setExtensions(Extensions $extensions): void
     {
         $this->extensions = $extensions;
         $samlExt = [];

--- a/src/SAML2/Extensions/ExtensionsMapperTrait.php
+++ b/src/SAML2/Extensions/ExtensionsMapperTrait.php
@@ -19,18 +19,18 @@ trait ExtensionsMapperTrait
             $rawExtensions = $this->request->getExtensions();
             /** @var SAML2Chunk $rawChunk */
             foreach ($rawExtensions as $rawChunk) {
-                switch ($rawChunk->localName) {
+                switch ($rawChunk->getLocalName()) {
                     case 'UserAttributes':
                         $this->extensions->addChunk(
-                            new GsspUserAttributesChunk($rawChunk->xml)
+                            new GsspUserAttributesChunk($rawChunk->getXML())
                         );
                         break;
                     default:
                         $this->extensions->addChunk(
                             new Chunk(
-                                $rawChunk->localName,
-                                $rawChunk->namespaceURI,
-                                $rawChunk->xml
+                                $rawChunk->getLocalName(),
+                                $rawChunk->getNamespaceURI(),
+                                $rawChunk->getXML()
                             )
                         );
                 }

--- a/src/SAML2/ReceivedAuthnRequest.php
+++ b/src/SAML2/ReceivedAuthnRequest.php
@@ -23,6 +23,7 @@ use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\Constants;
 use SAML2\DOMDocumentFactory;
 use SAML2\Message;
+use SAML2\XML\saml\NameID;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\Exception\RuntimeException;
 use Surfnet\SamlBundle\SAML2\Extensions\ExtensionsMapperTrait;
@@ -56,9 +57,7 @@ final class ReceivedAuthnRequest
         }
 
         // additional security against XXE Processing vulnerability
-        $previous = libxml_disable_entity_loader(true);
         $document = DOMDocumentFactory::fromString($decodedSamlRequest);
-        libxml_disable_entity_loader($previous);
 
         $authnRequest = Message::fromXML($document->firstChild);
 
@@ -105,7 +104,7 @@ final class ReceivedAuthnRequest
             return null;
         }
 
-        return $nameId->value;
+        return $nameId->getValue();
     }
 
     /**
@@ -118,7 +117,7 @@ final class ReceivedAuthnRequest
             return null;
         }
 
-        return $nameId->Format;
+        return $nameId->getFormat();
     }
 
     /**
@@ -135,10 +134,9 @@ final class ReceivedAuthnRequest
             throw InvalidArgumentException::invalidType('string', 'format', $format);
         }
 
-        $nameId = [
-            'Value' => $nameId,
-            'Format' => ($format ?: Constants::NAMEID_UNSPECIFIED)
-        ];
+        $nameId = new NameID();
+        $nameId->setValue($nameId);
+        $nameId->setFormat(($format ?: Constants::NAMEID_UNSPECIFIED));
 
         $this->request->setNameId($nameId);
     }

--- a/src/SAML2/Response/Assertion/InResponseTo.php
+++ b/src/SAML2/Response/Assertion/InResponseTo.php
@@ -48,10 +48,10 @@ class InResponseTo
 
         /** @var \SAML2\XML\saml\SubjectConfirmation $subjectConfirmation */
         $subjectConfirmation = $subjectConfirmationArray[0];
-        if (!$subjectConfirmation->SubjectConfirmationData) {
+        if (!$subjectConfirmation->getSubjectConfirmationData()) {
             return null;
         }
 
-        return $subjectConfirmation->SubjectConfirmationData->InResponseTo;
+        return $subjectConfirmation->getSubjectConfirmationData()->getInResponseTo();
     }
 }

--- a/src/SAML2/Response/Assertion/InResponseTo.php
+++ b/src/SAML2/Response/Assertion/InResponseTo.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -22,23 +22,14 @@ use SAML2\Assertion;
 
 class InResponseTo
 {
-    /**
-     * @param Assertion $assertion
-     * @param string    $inResponseTo
-     * @return bool
-     */
-    public static function assertEquals(Assertion $assertion, $inResponseTo)
+    public static function assertEquals(Assertion $assertion, mixed $inResponseTo): bool
     {
         $assertionInResponseTo = static::getInResponseTo($assertion);
 
         return $assertionInResponseTo === $inResponseTo;
     }
 
-    /**
-     * @param Assertion $assertion
-     * @return null|string
-     */
-    private static function getInResponseTo(Assertion $assertion)
+    private static function getInResponseTo(Assertion $assertion): ?string
     {
         $subjectConfirmationArray = $assertion->getSubjectConfirmation();
 
@@ -46,12 +37,7 @@ class InResponseTo
             return null;
         }
 
-        /** @var \SAML2\XML\saml\SubjectConfirmation $subjectConfirmation */
         $subjectConfirmation = $subjectConfirmationArray[0];
-        if (!$subjectConfirmation->getSubjectConfirmationData()) {
-            return null;
-        }
-
-        return $subjectConfirmation->getSubjectConfirmationData()->getInResponseTo();
+        return $subjectConfirmation->getSubjectConfirmationData()?->getInResponseTo();
     }
 }

--- a/src/SAML2/Response/AssertionAdapter.php
+++ b/src/SAML2/Response/AssertionAdapter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -25,20 +25,11 @@ use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
 
 class AssertionAdapter
 {
-    /**
-     * @var Assertion
-     */
-    private $assertion;
+    private Assertion $assertion;
 
-    /**
-     * @var AttributeSetInterface
-     */
-    private $attributeSet;
+    private AttributeSetInterface $attributeSet;
 
-    /**
-     * @var \Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary
-     */
-    private $attributeDictionary;
+    private AttributeDictionary $attributeDictionary;
 
     public function __construct(Assertion $assertion, AttributeDictionary $attributeDictionary)
     {
@@ -50,11 +41,11 @@ class AssertionAdapter
     /**
      * @return string
      */
-    public function getNameID()
+    public function getNameID(): ?string
     {
         $data = $this->assertion->getNameId();
         if ($data) {
-            return $data->value;
+            return $data->getValue();
         }
 
         return null;
@@ -65,7 +56,7 @@ class AssertionAdapter
      * @param mixed  $defaultValue  the value to return should the assertion not contain the attribute
      * @return string[]|mixed string[] if the attribute is found, the given default value otherwise
      */
-    public function getAttributeValue($attributeName, $defaultValue = null)
+    public function getAttributeValue($attributeName, $defaultValue = null): mixed
     {
         $attributeDefinition = $this->attributeDictionary->getAttributeDefinition($attributeName);
 
@@ -81,7 +72,7 @@ class AssertionAdapter
     /**
      * @return AttributeSetInterface
      */
-    public function getAttributeSet()
+    public function getAttributeSet(): AttributeSetInterface
     {
         return $this->attributeSet;
     }

--- a/src/Security/Authentication/AuthenticatedSessionStateHandler.php
+++ b/src/Security/Authentication/AuthenticatedSessionStateHandler.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication;
+
+use Surfnet\SamlBundle\Security\Exception\LogicException;
+use Surfnet\SamlBundle\Value\DateTime;
+
+interface AuthenticatedSessionStateHandler
+{
+    /**
+     * Sets the moment at which the user was authenticated
+     *
+     * @return void
+     * @throws LogicException when an authentication moment was already logged
+     */
+    public function logAuthenticationMoment();
+
+    /**
+     * @return bool
+     */
+    public function isAuthenticationMomentLogged();
+
+    /**
+     * Gets the moment at which the user was authenticated
+     *
+     * @return DateTime
+     * @throws LogicException when no authentication moment was logged
+     */
+    public function getAuthenticationMoment();
+
+    /**
+     * Updates the last interaction moment to the current moment
+     *
+     * @return void
+     */
+    public function updateLastInteractionMoment();
+
+    /**
+     * Retrieves the last interaction moment
+     *
+     * @return DateTime
+     */
+    public function getLastInteractionMoment();
+
+    /**
+     * @return bool
+     */
+    public function hasSeenInteraction();
+
+    /**
+     * @param string $uri
+     */
+    public function setCurrentRequestUri($uri);
+
+    /**
+     * @return string
+     */
+    public function getCurrentRequestUri();
+
+    /**
+     * Migrates the current session to a new session id while maintaining all
+     * session attributes.
+     */
+    public function migrate();
+
+    /**
+     * Invalidates the session
+     *
+     * Clears all session attributes and flashes and regenerates the
+     * session and deletes the old session from persistence
+     */
+    public function invalidate();
+}

--- a/src/Security/Authentication/AuthenticatedSessionStateHandler.php
+++ b/src/Security/Authentication/AuthenticatedSessionStateHandler.php
@@ -26,58 +26,40 @@ interface AuthenticatedSessionStateHandler
     /**
      * Sets the moment at which the user was authenticated
      *
-     * @return void
      * @throws LogicException when an authentication moment was already logged
      */
-    public function logAuthenticationMoment();
+    public function logAuthenticationMoment(): void;
 
-    /**
-     * @return bool
-     */
-    public function isAuthenticationMomentLogged();
+    public function isAuthenticationMomentLogged(): bool;
 
     /**
      * Gets the moment at which the user was authenticated
      *
-     * @return DateTime
      * @throws LogicException when no authentication moment was logged
      */
-    public function getAuthenticationMoment();
+    public function getAuthenticationMoment(): DateTime;
 
     /**
      * Updates the last interaction moment to the current moment
-     *
-     * @return void
      */
-    public function updateLastInteractionMoment();
+    public function updateLastInteractionMoment(): void;
 
     /**
      * Retrieves the last interaction moment
-     *
-     * @return DateTime
      */
-    public function getLastInteractionMoment();
+    public function getLastInteractionMoment(): DateTime;
 
-    /**
-     * @return bool
-     */
-    public function hasSeenInteraction();
+    public function hasSeenInteraction(): bool;
 
-    /**
-     * @param string $uri
-     */
-    public function setCurrentRequestUri($uri);
+    public function setCurrentRequestUri(string $uri);
 
-    /**
-     * @return string
-     */
-    public function getCurrentRequestUri();
+    public function getCurrentRequestUri(): string;
 
     /**
      * Migrates the current session to a new session id while maintaining all
      * session attributes.
      */
-    public function migrate();
+    public function migrate(): void;
 
     /**
      * Invalidates the session
@@ -85,5 +67,5 @@ interface AuthenticatedSessionStateHandler
      * Clears all session attributes and flashes and regenerates the
      * session and deletes the old session from persistence
      */
-    public function invalidate();
+    public function invalidate(): void;
 }

--- a/src/Security/Authentication/Handler/AuthenticationHandler.php
+++ b/src/Security/Authentication/Handler/AuthenticationHandler.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication\Handler;
+
+use SAML2\Assertion;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface AuthenticationHandler
+{
+    /**
+     * Checks if it can process the event and if so does so. Also determines if there
+     * is a next handler to be called if it cannot process the event itself.
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function process(Request $request): Assertion;
+}

--- a/src/Security/Authentication/Handler/FailureHandler.php
+++ b/src/Security/Authentication/Handler/FailureHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication\Handler;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+use Symfony\Component\Security\Http\HttpUtils;
+
+class FailureHandler extends DefaultAuthenticationFailureHandler
+{
+    public function __construct(
+        HttpKernelInterface $httpKernel,
+        HttpUtils $httpUtils,
+        array $options = [],
+        LoggerInterface $logger = null,
+    ) {
+        parent::__construct($httpKernel, $httpUtils, $options, $logger);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        $message = sprintf(
+            'Authentication failure: %s: "%s"',
+            $exception->getMessageKey(),
+            $exception->getMessage()
+        );
+        $this->logger->notice($message);
+
+        $responseBody = "
+            <!DOCTYPE html>
+            <html lang=\"en\">
+              <head>
+                <meta charset=\"utf-8\">
+                <title>Authentication failed</title>
+              </head>
+              <body>
+                $message
+              </body>
+            </html>";
+
+        return new Response($responseBody, Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/src/Security/Authentication/Handler/FailureHandler.php
+++ b/src/Security/Authentication/Handler/FailureHandler.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2023 SURFnet B.V.
@@ -28,15 +28,6 @@ use Symfony\Component\Security\Http\HttpUtils;
 
 class FailureHandler extends DefaultAuthenticationFailureHandler
 {
-    public function __construct(
-        HttpKernelInterface $httpKernel,
-        HttpUtils $httpUtils,
-        array $options = [],
-        LoggerInterface $logger = null,
-    ) {
-        parent::__construct($httpKernel, $httpUtils, $options, $logger);
-    }
-
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         $message = sprintf(

--- a/src/Security/Authentication/Handler/ProcessSamlAuthenticationHandler.php
+++ b/src/Security/Authentication/Handler/ProcessSamlAuthenticationHandler.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication\Handler;
+
+use Exception;
+use SAML2\Assertion;
+use SAML2\Response\Exception\PreconditionNotMetException;
+use Surfnet\SamlBundle\Http\Exception\AuthnFailedSamlResponseException;
+use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
+use Surfnet\SamlBundle\SAML2\Response\Assertion\InResponseTo;
+use Surfnet\SamlBundle\Security\Authentication\SamlAuthenticationStateHandler;
+use Surfnet\SamlBundle\Security\Authentication\SamlInteractionProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+class ProcessSamlAuthenticationHandler implements AuthenticationHandler
+{
+    public function __construct(
+        private readonly SamlInteractionProvider $samlInteractionProvider,
+        private readonly SamlAuthenticationStateHandler $authenticationStateHandler,
+        private readonly SamlAuthenticationLogger $authenticationLogger,
+    ) {
+    }
+
+    public function process(Request $request): Assertion
+    {
+        $expectedInResponseTo = $this->authenticationStateHandler->getRequestId();
+        $logger = $this->authenticationLogger->forAuthentication($expectedInResponseTo);
+
+        $logger->notice('No authenticated user and AuthnRequest pending, attempting to process SamlResponse');
+
+        try {
+            $assertion = $this->samlInteractionProvider->processSamlResponse($request);
+        } catch (AuthnFailedSamlResponseException $exception) {
+            $logger->notice(sprintf('SAML Authentication failed at IdP: "%s"', $exception->getMessage()));
+            throw new AuthenticationException('Failed SAMLResponse parsing', 0, $exception);
+        } catch (PreconditionNotMetException $exception) {
+            $logger->notice(sprintf('SAMLResponse precondition not met: "%s"', $exception->getMessage()));
+            throw new AuthenticationException('Failed SAMLResponse parsing', 0, $exception);
+        } catch (Exception $exception) {
+            $logger->error(sprintf('Failed SAMLResponse Parsing: "%s"', $exception->getMessage()));
+            throw new AuthenticationException('Failed SAMLResponse parsing', 0, $exception);
+        }
+        if (!InResponseTo::assertEquals($assertion, $expectedInResponseTo)) {
+            $logger->error('Unknown or unexpected InResponseTo in SAMLResponse');
+            throw new AuthenticationException('Unknown or unexpected InResponseTo in SAMLResponse');
+        }
+        return $assertion;
+    }
+}

--- a/src/Security/Authentication/Handler/ProcessSamlAuthenticationHandler.php
+++ b/src/Security/Authentication/Handler/ProcessSamlAuthenticationHandler.php
@@ -32,9 +32,9 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 class ProcessSamlAuthenticationHandler implements AuthenticationHandler
 {
     public function __construct(
-        private readonly SamlInteractionProvider $samlInteractionProvider,
-        private readonly SamlAuthenticationStateHandler $authenticationStateHandler,
-        private readonly SamlAuthenticationLogger $authenticationLogger,
+        private SamlInteractionProvider $samlInteractionProvider,
+        private SamlAuthenticationStateHandler $authenticationStateHandler,
+        private SamlAuthenticationLogger $authenticationLogger,
     ) {
     }
 

--- a/src/Security/Authentication/Handler/SuccessHandler.php
+++ b/src/Security/Authentication/Handler/SuccessHandler.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication\Handler;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
+use Symfony\Component\Security\Http\HttpUtils;
+
+class SuccessHandler extends DefaultAuthenticationSuccessHandler
+{
+    public function __construct(HttpUtils $httpUtils, array $options = [], LoggerInterface $logger = null)
+    {
+        parent::__construct($httpUtils, $options, $logger);
+    }
+}

--- a/src/Security/Authentication/Handler/SuccessHandler.php
+++ b/src/Security/Authentication/Handler/SuccessHandler.php
@@ -18,14 +18,8 @@
 
 namespace Surfnet\SamlBundle\Security\Authentication\Handler;
 
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
-use Symfony\Component\Security\Http\HttpUtils;
 
 class SuccessHandler extends DefaultAuthenticationSuccessHandler
 {
-    public function __construct(HttpUtils $httpUtils, array $options = [], LoggerInterface $logger = null)
-    {
-        parent::__construct($httpUtils, $options, $logger);
-    }
 }

--- a/src/Security/Authentication/Passport/Badge/SamlAttributesBadge.php
+++ b/src/Security/Authentication/Passport/Badge/SamlAttributesBadge.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\SamlBundle\Security\Authentication\Passport\Badge;
 
-use SAML2\XML\saml\NameID;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 
 class SamlAttributesBadge implements BadgeInterface
@@ -26,17 +25,6 @@ class SamlAttributesBadge implements BadgeInterface
     private array $attributes;
     public function __construct(array $attributes)
     {
-        foreach ($attributes as $key => $attributeParts) {
-            foreach ($attributeParts as $index => $attribute) {
-                // NameID can not be serialized, resulting in a 500 error during authentication
-                if ($attribute instanceof NameID) {
-                    $attributes[$key][$index] = [
-                        'Value' => $attribute->getValue(),
-                        'Format' => $attribute->getFormat()
-                    ];
-                }
-            }
-        }
         $this->attributes = $attributes;
     }
 

--- a/src/Security/Authentication/Passport/Badge/SamlAttributesBadge.php
+++ b/src/Security/Authentication/Passport/Badge/SamlAttributesBadge.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication\Passport\Badge;
+
+use SAML2\XML\saml\NameID;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
+
+class SamlAttributesBadge implements BadgeInterface
+{
+    private readonly array $attributes;
+    public function __construct(array $attributes)
+    {
+        foreach ($attributes as $key => $attributeParts) {
+            foreach ($attributeParts as $index => $attribute) {
+                // NameID can not be serialized, resulting in a 500 error during authentication
+                if ($attribute instanceof NameID) {
+                    $attributes[$key][$index] = [
+                        'Value' => $attribute->getValue(),
+                        'Format' => $attribute->getFormat()
+                    ];
+                }
+            }
+        }
+        $this->attributes = $attributes;
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function isResolved(): bool
+    {
+        return true;
+    }
+}

--- a/src/Security/Authentication/Passport/Badge/SamlAttributesBadge.php
+++ b/src/Security/Authentication/Passport/Badge/SamlAttributesBadge.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 
 class SamlAttributesBadge implements BadgeInterface
 {
-    private readonly array $attributes;
+    private array $attributes;
     public function __construct(array $attributes)
     {
         foreach ($attributes as $key => $attributeParts) {

--- a/src/Security/Authentication/Provider/SamlProviderInterface.php
+++ b/src/Security/Authentication/Provider/SamlProviderInterface.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication\Provider;
+
+use SAML2\Assertion;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+interface SamlProviderInterface
+{
+    public function getNameId(Assertion $assertion): string;
+
+    public function getUser(Assertion $assertion): UserInterface;
+}

--- a/src/Security/Authentication/SamlAuthenticationStateHandler.php
+++ b/src/Security/Authentication/SamlAuthenticationStateHandler.php
@@ -20,23 +20,14 @@ namespace Surfnet\SamlBundle\Security\Authentication;
 
 interface SamlAuthenticationStateHandler
 {
-    /**
-     * @return string
-     */
-    public function getRequestId();
+    public function getRequestId(): string;
 
-    /**
-     * @param string $requestId
-     */
-    public function setRequestId($requestId);
+    public function setRequestId(string $requestId): void;
 
-    /**
-     * @return bool
-     */
-    public function hasRequestId();
+    public function hasRequestId(): bool;
 
     /**
      * Removes the requestId from the session
      */
-    public function clearRequestId();
+    public function clearRequestId(): void;
 }

--- a/src/Security/Authentication/SamlAuthenticationStateHandler.php
+++ b/src/Security/Authentication/SamlAuthenticationStateHandler.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication;
+
+interface SamlAuthenticationStateHandler
+{
+    /**
+     * @return string
+     */
+    public function getRequestId();
+
+    /**
+     * @param string $requestId
+     */
+    public function setRequestId($requestId);
+
+    /**
+     * @return bool
+     */
+    public function hasRequestId();
+
+    /**
+     * Removes the requestId from the session
+     */
+    public function clearRequestId();
+}

--- a/src/Security/Authentication/SamlAuthenticator.php
+++ b/src/Security/Authentication/SamlAuthenticator.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication;
+
+use Psr\Log\LoggerInterface;
+use SAML2\Assertion;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Http\RedirectBinding;
+use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
+use Surfnet\SamlBundle\Security\Authentication\Handler\ProcessSamlAuthenticationHandler;
+use Surfnet\SamlBundle\Security\Authentication\Passport\Badge\SamlAttributesBadge;
+use Surfnet\SamlBundle\Security\Authentication\Provider\SamlProviderInterface;
+use Surfnet\SamlBundle\Security\Authentication\Token\SamlToken;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\LogicException;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+class SamlAuthenticator extends AbstractAuthenticator implements InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
+{
+    public function __construct(
+        private readonly IdentityProvider $identityProvider,
+        private readonly ServiceProvider $serviceProvider,
+        private readonly RedirectBinding $redirectBinding,
+        private readonly SamlAuthenticationStateHandler $samlAuthenticationStateHandler,
+        private readonly ProcessSamlAuthenticationHandler $processSamlAuthenticationHandler,
+        private readonly AuthenticationSuccessHandlerInterface $successHandler,
+        private readonly AuthenticationFailureHandlerInterface $failureHandler,
+        private readonly SamlProviderInterface $samlProvider,
+        private readonly RouterInterface $router,
+        private readonly LoggerInterface $logger,
+        private readonly string $acsRouteName
+    ) {
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        $authnRequest = AuthnRequestFactory::createNewRequest(
+            $this->serviceProvider,
+            $this->identityProvider
+        );
+
+        $this->samlAuthenticationStateHandler->setRequestId($authnRequest->getRequestId());
+        return $this->redirectBinding->createResponseFor($authnRequest);
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        $acsUri = $this->router->generate($this->acsRouteName);
+        return $request->getMethod() === 'POST' &&
+            $request->getRequestUri() === $acsUri &&
+            $request->request->has('SAMLResponse');
+    }
+
+    public function authenticate(Request $request)
+    {
+        $assertion = $this->processSamlAuthenticationHandler->process($request);
+        $this->logger->notice('Successfully processed SAMLResponse, attempting to authenticate');
+
+        return $this->createPassport($assertion);
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        if (!$passport->hasBadge(SamlAttributesBadge::class)) {
+            throw new LogicException(sprintf('Passport should contains a "%s" badge.', SamlAttributesBadge::class));
+        }
+
+        $badge = $passport->getBadge(SamlAttributesBadge::class);
+
+        return new SamlToken(
+            $passport->getUser(),
+            $firewallName,
+            $passport->getUser()->getRoles(),
+            $badge->getAttributes()
+        );
+    }
+
+    private function createPassport(Assertion $assertion): Passport
+    {
+        $nameId = $this->samlProvider->getNameId($assertion);
+
+        $userBadge = new UserBadge(
+            $nameId,
+            function ($identifier) use ($assertion) {
+                $this->logger->notice(sprintf('User Badge is loading a User with identifier %s', $identifier));
+                return $this->samlProvider->getUser($assertion);
+            }
+        );
+
+        return new SelfValidatingPassport(
+            $userBadge,
+            [new SamlAttributesBadge($assertion->getAttributes())]
+        );
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        $this->logger->notice(sprintf('Authentication succeeded for %s', $token->getUser()->getUserIdentifier()));
+        $this->samlAuthenticationStateHandler->clearRequestId();
+        return $this->successHandler->onAuthenticationSuccess($request, $token);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        return $this->failureHandler->onAuthenticationFailure($request, $exception);
+    }
+
+    public function isInteractive(): bool
+    {
+        return true;
+    }
+}

--- a/src/Security/Authentication/SamlAuthenticator.php
+++ b/src/Security/Authentication/SamlAuthenticator.php
@@ -42,6 +42,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use function dd;
 
 class SamlAuthenticator extends AbstractAuthenticator implements InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
 {

--- a/src/Security/Authentication/SamlAuthenticator.php
+++ b/src/Security/Authentication/SamlAuthenticator.php
@@ -52,17 +52,17 @@ class SamlAuthenticator extends AbstractAuthenticator implements InteractiveAuth
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
-        private readonly IdentityProvider $identityProvider,
-        private readonly ServiceProvider $serviceProvider,
-        private readonly RedirectBinding $redirectBinding,
-        private readonly SamlAuthenticationStateHandler $samlAuthenticationStateHandler,
-        private readonly ProcessSamlAuthenticationHandler $processSamlAuthenticationHandler,
-        private readonly AuthenticationSuccessHandlerInterface $successHandler,
-        private readonly AuthenticationFailureHandlerInterface $failureHandler,
-        private readonly SamlProviderInterface $samlProvider,
-        private readonly RouterInterface $router,
-        private readonly LoggerInterface $logger,
-        private readonly string $acsRouteName
+        private IdentityProvider $identityProvider,
+        private ServiceProvider $serviceProvider,
+        private RedirectBinding $redirectBinding,
+        private SamlAuthenticationStateHandler $samlAuthenticationStateHandler,
+        private ProcessSamlAuthenticationHandler $processSamlAuthenticationHandler,
+        private AuthenticationSuccessHandlerInterface $successHandler,
+        private AuthenticationFailureHandlerInterface $failureHandler,
+        private SamlProviderInterface $samlProvider,
+        private RouterInterface $router,
+        private LoggerInterface $logger,
+        private string $acsRouteName
     ) {
     }
 

--- a/src/Security/Authentication/SamlAuthenticator.php
+++ b/src/Security/Authentication/SamlAuthenticator.php
@@ -42,10 +42,15 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
-use function dd;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class SamlAuthenticator extends AbstractAuthenticator implements InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
 {
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
     public function __construct(
         private readonly IdentityProvider $identityProvider,
         private readonly ServiceProvider $serviceProvider,
@@ -61,7 +66,7 @@ class SamlAuthenticator extends AbstractAuthenticator implements InteractiveAuth
     ) {
     }
 
-    public function start(Request $request, AuthenticationException $authException = null)
+    public function start(Request $request, AuthenticationException $authException = null): Response
     {
         $authnRequest = AuthnRequestFactory::createNewRequest(
             $this->serviceProvider,
@@ -80,7 +85,7 @@ class SamlAuthenticator extends AbstractAuthenticator implements InteractiveAuth
             $request->request->has('SAMLResponse');
     }
 
-    public function authenticate(Request $request)
+    public function authenticate(Request $request): Passport
     {
         $assertion = $this->processSamlAuthenticationHandler->process($request);
         $this->logger->notice('Successfully processed SAMLResponse, attempting to authenticate');

--- a/src/Security/Authentication/SamlInteractionProvider.php
+++ b/src/Security/Authentication/SamlInteractionProvider.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication;
+
+use SAML2\Assertion;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Http\PostBinding;
+use Surfnet\SamlBundle\Http\RedirectBinding;
+use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
+use Surfnet\SamlBundle\Security\Exception\UnexpectedIssuerException;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class SamlInteractionProvider
+{
+    public function __construct(
+        private readonly ServiceProvider $serviceProvider,
+        private readonly IdentityProvider $identityProvider,
+        private readonly RedirectBinding $redirectBinding,
+        private readonly PostBinding $postBinding,
+        private readonly SamlAuthenticationStateHandler $samlAuthenticationStateHandler
+    ) {
+    }
+
+    public function isSamlAuthenticationInitiated(): bool
+    {
+        return $this->samlAuthenticationStateHandler->hasRequestId();
+    }
+
+    public function initiateSamlRequest(): RedirectResponse
+    {
+        $authnRequest = AuthnRequestFactory::createNewRequest(
+            $this->serviceProvider,
+            $this->identityProvider
+        );
+
+        $this->samlAuthenticationStateHandler->setRequestId($authnRequest->getRequestId());
+
+        return $this->redirectBinding->createResponseFor($authnRequest);
+    }
+
+    public function processSamlResponse(Request $request): Assertion
+    {
+        $assertion = $this->postBinding->processResponse(
+            $request,
+            $this->identityProvider,
+            $this->serviceProvider
+        );
+
+        if ($assertion->getIssuer()->getValue() !== $this->identityProvider->getEntityId()) {
+            throw new UnexpectedIssuerException(sprintf(
+                'Expected issuer to be configured remote IdP "%s", got "%s"',
+                $this->identityProvider->getEntityId(),
+                $assertion->getIssuer()->getValue()
+            ));
+        }
+        return $assertion;
+    }
+
+    /**
+     * Resets the SAML flow.
+     */
+    public function reset(): void
+    {
+        $this->samlAuthenticationStateHandler->clearRequestId();
+    }
+}

--- a/src/Security/Authentication/SamlInteractionProvider.php
+++ b/src/Security/Authentication/SamlInteractionProvider.php
@@ -31,11 +31,11 @@ use Symfony\Component\HttpFoundation\Request;
 class SamlInteractionProvider
 {
     public function __construct(
-        private readonly ServiceProvider $serviceProvider,
-        private readonly IdentityProvider $identityProvider,
-        private readonly RedirectBinding $redirectBinding,
-        private readonly PostBinding $postBinding,
-        private readonly SamlAuthenticationStateHandler $samlAuthenticationStateHandler
+        private ServiceProvider $serviceProvider,
+        private IdentityProvider $identityProvider,
+        private RedirectBinding $redirectBinding,
+        private PostBinding $postBinding,
+        private SamlAuthenticationStateHandler $samlAuthenticationStateHandler
     ) {
     }
 

--- a/src/Security/Authentication/Session/SessionStorage.php
+++ b/src/Security/Authentication/Session/SessionStorage.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication\Session;
+
+use Surfnet\SamlBundle\Security\Authentication\AuthenticatedSessionStateHandler;
+use Surfnet\SamlBundle\Security\Authentication\SamlAuthenticationStateHandler;
+use Surfnet\SamlBundle\Security\Exception\LogicException;
+use Surfnet\SamlBundle\Value\DateTime;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthenticationStateHandler
+{
+    /**
+     * Session keys
+     */
+    const AUTH_SESSION_KEY = '__auth/';
+    const SAML_SESSION_KEY = '__saml/';
+
+    public function __construct(private readonly SessionInterface $session)
+    {
+    }
+
+    public function logAuthenticationMoment()
+    {
+        if ($this->isAuthenticationMomentLogged()) {
+            throw new LogicException('Cannot log authentication moment as an authentication moment is already logged');
+        }
+
+        $this->session->set(self::AUTH_SESSION_KEY . 'authenticated_at', DateTime::now()->format(DateTime::FORMAT));
+        $this->updateLastInteractionMoment();
+    }
+
+    public function isAuthenticationMomentLogged()
+    {
+        return $this->session->get(self::AUTH_SESSION_KEY . 'authenticated_at', null) !== null;
+    }
+
+    public function getAuthenticationMoment()
+    {
+        if (!$this->isAuthenticationMomentLogged()) {
+            throw new LogicException('Cannot get last authentication moment as no authentication has been set');
+        }
+
+        return DateTime::fromString($this->session->get(self::AUTH_SESSION_KEY . 'authenticated_at'));
+    }
+
+    public function updateLastInteractionMoment()
+    {
+        $this->session->set(self::AUTH_SESSION_KEY . 'last_interaction', DateTime::now()->format(DateTime::FORMAT));
+    }
+
+    public function hasSeenInteraction()
+    {
+        return $this->session->get(self::AUTH_SESSION_KEY . 'last_interaction', null) !== null;
+    }
+
+    public function getLastInteractionMoment()
+    {
+        if (!$this->hasSeenInteraction()) {
+            throw new LogicException('Cannot get last interaction moment as we have not seen any interaction');
+        }
+
+        return DateTime::fromString($this->session->get(self::AUTH_SESSION_KEY . 'last_interaction'));
+    }
+
+    public function setCurrentRequestUri($uri)
+    {
+        $this->session->set(self::AUTH_SESSION_KEY . 'current_uri', $uri);
+    }
+
+    public function getCurrentRequestUri()
+    {
+        $uri = $this->session->get(self::AUTH_SESSION_KEY . 'current_uri');
+        $this->session->remove(self::AUTH_SESSION_KEY . 'current_uri');
+
+        return $uri;
+    }
+
+    public function getRequestId()
+    {
+        return $this->session->get(self::SAML_SESSION_KEY . 'request_id');
+    }
+
+    public function setRequestId($requestId)
+    {
+        $this->session->set(self::SAML_SESSION_KEY . 'request_id', $requestId);
+    }
+
+    public function hasRequestId()
+    {
+        $value =  $this->session->has(self::SAML_SESSION_KEY . 'request_id');
+        return $value;
+    }
+
+    public function clearRequestId()
+    {
+        $this->session->remove(self::SAML_SESSION_KEY . 'request_id');
+    }
+
+    public function invalidate()
+    {
+        $this->session->invalidate();
+    }
+
+    public function migrate()
+    {
+        $this->session->migrate();
+    }
+}

--- a/src/Security/Authentication/Session/SessionStorage.php
+++ b/src/Security/Authentication/Session/SessionStorage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2017 SURFnet B.V.
@@ -29,14 +29,14 @@ class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthentica
     /**
      * Session keys
      */
-    const AUTH_SESSION_KEY = '__auth/';
-    const SAML_SESSION_KEY = '__saml/';
+    private const AUTH_SESSION_KEY = '__auth/';
+    private const SAML_SESSION_KEY = '__saml/';
 
     public function __construct(private SessionInterface $session)
     {
     }
 
-    public function logAuthenticationMoment()
+    public function logAuthenticationMoment(): void
     {
         if ($this->isAuthenticationMomentLogged()) {
             throw new LogicException('Cannot log authentication moment as an authentication moment is already logged');
@@ -46,12 +46,12 @@ class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthentica
         $this->updateLastInteractionMoment();
     }
 
-    public function isAuthenticationMomentLogged()
+    public function isAuthenticationMomentLogged(): bool
     {
         return $this->session->get(self::AUTH_SESSION_KEY . 'authenticated_at', null) !== null;
     }
 
-    public function getAuthenticationMoment()
+    public function getAuthenticationMoment(): DateTime
     {
         if (!$this->isAuthenticationMomentLogged()) {
             throw new LogicException('Cannot get last authentication moment as no authentication has been set');
@@ -60,17 +60,17 @@ class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthentica
         return DateTime::fromString($this->session->get(self::AUTH_SESSION_KEY . 'authenticated_at'));
     }
 
-    public function updateLastInteractionMoment()
+    public function updateLastInteractionMoment(): void
     {
         $this->session->set(self::AUTH_SESSION_KEY . 'last_interaction', DateTime::now()->format(DateTime::FORMAT));
     }
 
-    public function hasSeenInteraction()
+    public function hasSeenInteraction(): bool
     {
         return $this->session->get(self::AUTH_SESSION_KEY . 'last_interaction', null) !== null;
     }
 
-    public function getLastInteractionMoment()
+    public function getLastInteractionMoment(): DateTime
     {
         if (!$this->hasSeenInteraction()) {
             throw new LogicException('Cannot get last interaction moment as we have not seen any interaction');
@@ -79,7 +79,7 @@ class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthentica
         return DateTime::fromString($this->session->get(self::AUTH_SESSION_KEY . 'last_interaction'));
     }
 
-    public function setCurrentRequestUri($uri)
+    public function setCurrentRequestUri($uri): void
     {
         $this->session->set(self::AUTH_SESSION_KEY . 'current_uri', $uri);
     }
@@ -113,12 +113,12 @@ class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthentica
         $this->session->remove(self::SAML_SESSION_KEY . 'request_id');
     }
 
-    public function invalidate()
+    public function invalidate(): void
     {
         $this->session->invalidate();
     }
 
-    public function migrate()
+    public function migrate(): void
     {
         $this->session->migrate();
     }

--- a/src/Security/Authentication/Session/SessionStorage.php
+++ b/src/Security/Authentication/Session/SessionStorage.php
@@ -84,7 +84,7 @@ class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthentica
         $this->session->set(self::AUTH_SESSION_KEY . 'current_uri', $uri);
     }
 
-    public function getCurrentRequestUri()
+    public function getCurrentRequestUri(): string
     {
         $uri = $this->session->get(self::AUTH_SESSION_KEY . 'current_uri');
         $this->session->remove(self::AUTH_SESSION_KEY . 'current_uri');
@@ -92,23 +92,23 @@ class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthentica
         return $uri;
     }
 
-    public function getRequestId()
+    public function getRequestId(): string
     {
         return $this->session->get(self::SAML_SESSION_KEY . 'request_id');
     }
 
-    public function setRequestId($requestId)
+    public function setRequestId(string $requestId): void
     {
         $this->session->set(self::SAML_SESSION_KEY . 'request_id', $requestId);
     }
 
-    public function hasRequestId()
+    public function hasRequestId(): bool
     {
         $value =  $this->session->has(self::SAML_SESSION_KEY . 'request_id');
         return $value;
     }
 
-    public function clearRequestId()
+    public function clearRequestId(): void
     {
         $this->session->remove(self::SAML_SESSION_KEY . 'request_id');
     }

--- a/src/Security/Authentication/Session/SessionStorage.php
+++ b/src/Security/Authentication/Session/SessionStorage.php
@@ -32,7 +32,7 @@ class SessionStorage implements AuthenticatedSessionStateHandler, SamlAuthentica
     const AUTH_SESSION_KEY = '__auth/';
     const SAML_SESSION_KEY = '__saml/';
 
-    public function __construct(private readonly SessionInterface $session)
+    public function __construct(private SessionInterface $session)
     {
     }
 

--- a/src/Security/Authentication/Token/SamlToken.php
+++ b/src/Security/Authentication/Token/SamlToken.php
@@ -18,7 +18,6 @@
 
 namespace Surfnet\SamlBundle\Security\Authentication\Token;
 
-use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 
@@ -31,33 +30,7 @@ class SamlToken extends PostAuthenticationToken
         $this->setAttributes($attributes);
     }
 
-    /**
-     * Check if token contains given role.
-     *
-     * @param string $expected
-     * @return bool
-     */
-    public function hasRole($expected)
-    {
-        foreach ($this->getRoleNames() as $role) {
-            if ($role instanceof Role) {
-                $role = $role->getRole();
-            }
-
-            if ($role === $expected) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Returns the user credentials.
-     *
-     * @return mixed The user credentials
-     */
-    public function getCredentials()
+    public function getCredentials(): string
     {
         return '';
     }

--- a/src/Security/Authentication/Token/SamlToken.php
+++ b/src/Security/Authentication/Token/SamlToken.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication\Token;
+
+use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+
+class SamlToken extends PostAuthenticationToken
+{
+    public function __construct(UserInterface $user, string $firewallName, array $roles, array $attributes)
+    {
+        parent::__construct($user, $firewallName, $roles);
+
+        $this->setAttributes($attributes);
+    }
+
+    /**
+     * Check if token contains given role.
+     *
+     * @param string $expected
+     * @return bool
+     */
+    public function hasRole($expected)
+    {
+        foreach ($this->getRoleNames() as $role) {
+            if ($role instanceof Role) {
+                $role = $role->getRole();
+            }
+
+            if ($role === $expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the user credentials.
+     *
+     * @return mixed The user credentials
+     */
+    public function getCredentials()
+    {
+        return '';
+    }
+}

--- a/src/Security/Exception/LogicException.php
+++ b/src/Security/Exception/LogicException.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Exception;
+
+use LogicException as CoreLogicException;
+
+class LogicException extends CoreLogicException
+{
+}

--- a/src/Security/Exception/RuntimeException.php
+++ b/src/Security/Exception/RuntimeException.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Exception;
+
+use RuntimeException as CoreRuntimeException;
+
+class RuntimeException extends CoreRuntimeException
+{
+}

--- a/src/Security/Exception/UnexpectedIssuerException.php
+++ b/src/Security/Exception/UnexpectedIssuerException.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Exception;
+
+class UnexpectedIssuerException extends RuntimeException
+{
+}

--- a/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
+++ b/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2021 SURF B.V.

--- a/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
+++ b/src/Tests/Component/Extensions/AuthnRequestExtensionsTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Component\Extensions;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\DOMDocumentFactory;
@@ -30,7 +30,7 @@ use function file_get_contents;
 class AuthnRequestExtensionsTest extends TestCase
 {
 
-    public function test_extensions_are_retrievable()
+    public function test_extensions_are_retrievable(): void
     {
         $authnRequest = $this->createSignedAuthnRequest(
             [$this, 'encodeDataToSignWithPhpsHttpBuildQuery']
@@ -51,7 +51,7 @@ class AuthnRequestExtensionsTest extends TestCase
         );
     }
 
-    public function test_setting_of_extensions()
+    public function test_setting_of_extensions(): void
     {
         $authnRequest = $this->createSignedAuthnRequest(
             [$this, 'encodeDataToSignWithPhpsHttpBuildQuery'],
@@ -98,7 +98,7 @@ class AuthnRequestExtensionsTest extends TestCase
      * @param array $params
      * @return string
      */
-    private function encodeDataToSignWithPhpsHttpBuildQuery(array $params)
+    private function encodeDataToSignWithPhpsHttpBuildQuery(array $params): string
     {
         return http_build_query($params);
     }
@@ -114,7 +114,7 @@ class AuthnRequestExtensionsTest extends TestCase
         callable $prepareDataToSign,
         $customSignature = null,
         $source = '/with_extensions.xml'
-    ) {
+    ): AuthnRequest {
         $keyData    = file_get_contents(__DIR__.'/../../../Resources/keys/development_privatekey.pem');
         $privateKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
         $privateKey->loadKey($keyData);

--- a/src/Tests/Component/Extensions/ChunkSerializationTest.php
+++ b/src/Tests/Component/Extensions/ChunkSerializationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2021 SURF B.V.

--- a/src/Tests/Component/Extensions/ChunkSerializationTest.php
+++ b/src/Tests/Component/Extensions/ChunkSerializationTest.php
@@ -18,13 +18,13 @@
 
 namespace Surfnet\SamlBundle\Tests\Component\Extensions;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Surfnet\SamlBundle\SAML2\Extensions\GsspUserAttributesChunk;
 
 class ChunkSerializationTest extends TestCase
 {
 
-    public function test_gsspchunk_is_serializable()
+    public function test_gsspchunk_is_serializable(): void
     {
         $chunk = new GsspUserAttributesChunk();
         $chunk->addAttribute(

--- a/src/Tests/Component/Metadata/MetadataFactoryTest.php
+++ b/src/Tests/Component/Metadata/MetadataFactoryTest.php
@@ -20,7 +20,8 @@ namespace Surfnet\SamlBundle\Tests\Component\Metadata;
 
 use Jasny\PHPUnit\Constraint\XSDValidation;
 use Mockery as m;
-use PHPUnit_Framework_TestCase as TestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use SAML2\Certificate\KeyLoader;
 use SAML2\Certificate\PrivateKeyLoader;
 use Surfnet\SamlBundle\Metadata\MetadataConfiguration;
@@ -30,10 +31,10 @@ use Surfnet\SamlBundle\Signing\Signable;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Loader\ArrayLoader;
 use Twig\Environment;
-use function file_get_contents;
 
 class MetadataFactoryTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
     /** @var MetadataFactory */
     public $factory;
 
@@ -43,7 +44,7 @@ class MetadataFactoryTest extends TestCase
 
     public $signingService;
 
-    public function setUp()
+    public function setUp(): void
     {
         // Load the XML template from filesystem as the FilesystemLoader does not honour the bundle prefix
         $loader = new ArrayLoader(
@@ -56,7 +57,7 @@ class MetadataFactoryTest extends TestCase
         $this->router->shouldReceive('generate')->andReturn('https://foobar.example.com');
     }
 
-    public function test_valid_metadata_xml()
+    public function test_valid_metadata_xml(): void
     {
         $expectedResult = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -69,7 +70,7 @@ XML;
         self::assertEquals($expectedResult, $metadata->__toString());
     }
 
-    public function test_builds_sp_metadata()
+    public function test_builds_sp_metadata(): void
     {
         $expectedResult = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -89,7 +90,7 @@ XML;
         self::assertEquals($expectedResult, $metadata->__toString());
     }
 
-    public function test_builds_idp_metadata()
+    public function test_builds_idp_metadata(): void
     {
         $expectedResult = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -119,7 +120,7 @@ XML;
         self::assertThat($metadata->document, $constraint);
     }
 
-    public function test_builds_idp_metadata_signed()
+    public function test_builds_idp_metadata_signed(): void
     {
         $metadataConfiguration = new MetadataConfiguration();
         $metadataConfiguration->isIdP = true;
@@ -138,7 +139,7 @@ XML;
         self::assertThat($metadata->document, $constraint);
     }
 
-    private function buildFactory(MetadataConfiguration $metadata, SigningService $signingService = null)
+    private function buildFactory(MetadataConfiguration $metadata, SigningService $signingService = null): void
     {
         if (!$signingService) {
             $signingService = m::mock(SigningService::class);

--- a/src/Tests/Component/Metadata/MetadataFactoryTest.php
+++ b/src/Tests/Component/Metadata/MetadataFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2021 SURF B.V.
@@ -36,13 +36,11 @@ class MetadataFactoryTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
     /** @var MetadataFactory */
-    public $factory;
+    public MetadataFactory $factory;
 
-    public $twig;
+    public Environment $twig;
 
-    public $router;
-
-    public $signingService;
+    public m\Mock|RouterInterface $router;
 
     public function setUp(): void
     {

--- a/src/Tests/Component/Signing/AuthnRequestSigningTest.php
+++ b/src/Tests/Component/Signing/AuthnRequestSigningTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Component\Signing;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
@@ -57,7 +57,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @group Signing
      * @group Deprecated
      */
-    public function deprecated_authn_request_signatures_are_verified_if_the_sender_uses_rfc1738_encoding()
+    public function deprecated_authn_request_signatures_are_verified_if_the_sender_uses_rfc1738_encoding(): void
     {
         $authnRequestWithDefaultEncoding = $this->createSignedAuthnRequest(
             [$this, 'encodeDataToSignWithPhpsHttpBuildQuery']
@@ -83,7 +83,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @group Signing
      * @group Deprecated
      */
-    public function deprecated_authn_request_signatures_are_verified_if_the_sender_uses_something_other_than_rfc1738_encoding()
+    public function deprecated_authn_request_signatures_are_verified_if_the_sender_uses_something_other_than_rfc1738_encoding(): void
     {
         $authnRequestWithCustomEncoding  = $this->createSignedAuthnRequest(
             [$this, 'encodeDataToSignWithCustomHttpQueryEncoding']
@@ -108,7 +108,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @group Signing
      * @group Deprecated
      */
-    public function deprecated_authn_request_signatures_are_not_verified_if_the_data_to_sign_does_not_correspond_with_the_signature_sent()
+    public function deprecated_authn_request_signatures_are_not_verified_if_the_data_to_sign_does_not_correspond_with_the_signature_sent(): void
     {
         $authnRequestWithModifiedDataToSign = $this->createSignedAuthnRequest(
             [$this, 'encodeDataToSignWithPhpsHttpBuildQuery'],
@@ -133,7 +133,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @group Signing
      * @group Deprecated
      */
-    public function deprecated_authn_request_signatures_are_not_verified_if_the_parameter_order_of_the_sent_query_is_not_correct()
+    public function deprecated_authn_request_signatures_are_not_verified_if_the_parameter_order_of_the_sent_query_is_not_correct(): void
     {
         $authnRequestWithModifiedDataToSign = $this->createSignedAuthnRequest(
             [$this, 'encodeDataToSignUsingIncorrectParameterOrder']
@@ -156,7 +156,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group Signing
      */
-    public function a_received_authn_requests_signature_is_verified_regardless_of_its_encoding()
+    public function a_received_authn_requests_signature_is_verified_regardless_of_its_encoding(): void
     {
         $signatureVerifier = new SignatureVerifier(new KeyLoader, new NullLogger);
         $certificate       = X509::createFromCertificateData($this->getPublicKey());
@@ -212,7 +212,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group Signing
      */
-    public function a_received_authn_requests_signature_is_not_verified_if_the_data_to_sign_does_not_correspond_with_the_signature_sent()
+    public function a_received_authn_requests_signature_is_not_verified_if_the_data_to_sign_does_not_correspond_with_the_signature_sent(): void
     {
         $signatureVerifier = new SignatureVerifier(new KeyLoader, new NullLogger);
         $certificate       = X509::createFromCertificateData($this->getPublicKey());
@@ -238,20 +238,12 @@ AUTHNREQUEST_NO_SUBJECT;
         );
     }
 
-    /**
-     * @param array $params
-     * @return string
-     */
-    private function encodeDataToSignWithPhpsHttpBuildQuery(array $params)
+    private function encodeDataToSignWithPhpsHttpBuildQuery(array $params): string
     {
         return http_build_query($params);
     }
 
-    /**
-     * @param array $params
-     * @return string
-     */
-    private function encodeDataToSignWithCustomHttpQueryEncoding(array $params)
+    private function encodeDataToSignWithCustomHttpQueryEncoding(array $params): string
     {
         $encodedParams = http_build_query($params);
 
@@ -260,11 +252,7 @@ AUTHNREQUEST_NO_SUBJECT;
         return str_replace('%3A', ':', $encodedParams);
     }
 
-    /**
-     * @param array $params
-     * @return string
-     */
-    private function encodeDataToSignUsingIncorrectParameterOrder(array $params)
+    private function encodeDataToSignUsingIncorrectParameterOrder(array $params): string
     {
         return http_build_query(array_reverse($params, true));
     }
@@ -272,9 +260,8 @@ AUTHNREQUEST_NO_SUBJECT;
     /**
      * @param callable $prepareDataToSign Expects an associative array of data to sign and returns a string to sign
      * @param null|string $customSignature Signature to be used instead of signature to sign data to sign with
-     * @return AuthnRequest
      */
-    private function createSignedAuthnRequest(callable $prepareDataToSign, $customSignature = null)
+    private function createSignedAuthnRequest(callable $prepareDataToSign, ?string $customSignature = null): AuthnRequest
     {
         $keyData    = file_get_contents(__DIR__.'/../../../Resources/keys/development_privatekey.pem');
         $privateKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
@@ -307,7 +294,7 @@ AUTHNREQUEST_NO_SUBJECT;
         );
     }
 
-    private function getPublicKey()
+    private function getPublicKey(): string
     {
         if ($this->publicKey === null) {
             $file = file_get_contents(__DIR__.'/../../../Resources/keys/development_publickey.cer');
@@ -317,10 +304,7 @@ AUTHNREQUEST_NO_SUBJECT;
         return $this->publicKey;
     }
 
-    /**
-     * @return string
-     */
-    private function createEncodedSamlRequest()
+    private function createEncodedSamlRequest(): string
     {
         $domDocument          = DOMDocumentFactory::fromString($this->authRequestNoSubject);
         $unsignedAuthnRequest = SAML2AuthnRequest::fromXML($domDocument->firstChild);

--- a/src/Tests/Component/Signing/AuthnRequestSigningTest.php
+++ b/src/Tests/Component/Signing/AuthnRequestSigningTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2016 SURFnet B.V.
@@ -31,10 +31,7 @@ use Surfnet\SamlBundle\Signing\SignatureVerifier;
 
 class AuthnRequestSigningTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $authRequestNoSubject = <<<AUTHNREQUEST_NO_SUBJECT
+    private string $authRequestNoSubject = <<<AUTHNREQUEST_NO_SUBJECT
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -47,10 +44,7 @@ class AuthnRequestSigningTest extends TestCase
 </samlp:AuthnRequest>
 AUTHNREQUEST_NO_SUBJECT;
 
-    /**
-     * @var string|null
-     */
-    private $publicKey = null;
+    private ?string $publicKey = null;
 
     /**
      * @test
@@ -290,7 +284,7 @@ AUTHNREQUEST_NO_SUBJECT;
             $encodedRequest,
             null,
             $signature,
-            $privateKey->type
+            (string) $privateKey->type
         );
     }
 

--- a/src/Tests/TestSaml2Container.php
+++ b/src/Tests/TestSaml2Container.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -18,24 +18,19 @@
 
 namespace Surfnet\SamlBundle\Tests;
 
+use BadMethodCallException;
 use SAML2\Compat\AbstractContainer;
 use Psr\Log\LoggerInterface;
 
 class TestSaml2Container extends AbstractContainer
 {
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }
 
-    /**
-     * @return LoggerInterface
-     */
     public function getLogger(): LoggerInterface
     {
         return $this->logger;
@@ -46,7 +41,7 @@ class TestSaml2Container extends AbstractContainer
      */
     public function generateId() : string
     {
-        return 1;
+        return '1';
     }
 
     public function debugMessage($message, string $type) : void
@@ -56,20 +51,24 @@ class TestSaml2Container extends AbstractContainer
 
     public function redirect(string $url, array $data = []) : void
     {
-        throw new \BadMethodCallException(sprintf(
-            "[TEST] %s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
-            __CLASS__,
-            __METHOD__
-        ));
+        throw new BadMethodCallException(
+            sprintf(
+                "[TEST] %s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
+                __CLASS__,
+                __METHOD__
+            )
+        );
     }
 
     public function postRedirect(string $url, array $data = []) : void
     {
-        throw new \BadMethodCallException(sprintf(
-            "[TEST] %s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
-            __CLASS__,
-            __METHOD__
-        ));
+        throw new BadMethodCallException(
+            sprintf(
+                "[TEST] %s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
+                __CLASS__,
+                __METHOD__
+            )
+        );
     }
 
     public function getTempDir(): string

--- a/src/Tests/TestSaml2Container.php
+++ b/src/Tests/TestSaml2Container.php
@@ -36,7 +36,7 @@ class TestSaml2Container extends AbstractContainer
     /**
      * @return LoggerInterface
      */
-    public function getLogger()
+    public function getLogger(): LoggerInterface
     {
         return $this->logger;
     }
@@ -44,17 +44,17 @@ class TestSaml2Container extends AbstractContainer
     /**
      * Generate a random identifier for identifying SAML2 documents.
      */
-    public function generateId()
+    public function generateId() : string
     {
         return 1;
     }
 
-    public function debugMessage($message, $type)
+    public function debugMessage($message, string $type) : void
     {
         $this->logger->debug($message, ['type' => $type]);
     }
 
-    public function redirect($url, $data = array())
+    public function redirect(string $url, array $data = []) : void
     {
         throw new \BadMethodCallException(sprintf(
             "[TEST] %s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
@@ -63,12 +63,22 @@ class TestSaml2Container extends AbstractContainer
         ));
     }
 
-    public function postRedirect($url, $data = array())
+    public function postRedirect(string $url, array $data = []) : void
     {
         throw new \BadMethodCallException(sprintf(
             "[TEST] %s:%s may not be called in the Surfnet\\SamlBundle as it doesn't work with Symfony2",
             __CLASS__,
             __METHOD__
         ));
+    }
+
+    public function getTempDir(): string
+    {
+        // TODO: Implement getTempDir() method.
+    }
+
+    public function writeFile(string $filename, string $data, int $mode = null): void
+    {
+        // TODO: Implement writeFile() method.
     }
 }

--- a/src/Tests/Unit/Http/HttpBindingFactoryTest.php
+++ b/src/Tests/Unit/Http/HttpBindingFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2017 SURFnet bv
@@ -29,14 +29,11 @@ class HttpBindingFactoryTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /** @var HttpBindingFactory */
-    private $factory;
+    private HttpBindingFactory $factory;
 
-    /** @var Request|Mockery\Mock */
-    private $request;
+    private Request|Mockery\Mock $request;
 
-    /** @var ParameterBag|Mockery\Mock */
-    private $bag;
+    private ParameterBag|Mockery\Mock $bag;
 
     public function setUp(): void
     {
@@ -53,7 +50,7 @@ class HttpBindingFactoryTest extends TestCase
      * @test
      * @group http
      */
-    public function a_redirect_binding_can_be_built()
+    public function a_redirect_binding_can_be_built(): void
     {
         $this->request
             ->shouldReceive('getMethod')
@@ -73,7 +70,7 @@ class HttpBindingFactoryTest extends TestCase
      * @test
      * @group http
      */
-    public function a_post_binding_can_be_built()
+    public function a_post_binding_can_be_built(): void
     {
         $this->request
             ->shouldReceive('getMethod')
@@ -93,7 +90,7 @@ class HttpBindingFactoryTest extends TestCase
      * @test
      * @group http
      */
-    public function a_put_binding_can_not_be_built()
+    public function a_put_binding_can_not_be_built(): void
     {
         $this->expectExceptionMessage("Request type of \"PUT\" is not supported.");
         $this->expectException(\Surfnet\SamlBundle\Exception\InvalidArgumentException::class);
@@ -108,7 +105,7 @@ class HttpBindingFactoryTest extends TestCase
      * @test
      * @group http
      */
-    public function an_invalid_post_authn_request_is_rejected()
+    public function an_invalid_post_authn_request_is_rejected(): void
     {
         $this->expectExceptionMessage("POST-binding is supported for SAMLRequest.");
         $this->expectException(\Surfnet\SamlBundle\Exception\InvalidArgumentException::class);
@@ -128,7 +125,7 @@ class HttpBindingFactoryTest extends TestCase
      * @test
      * @group http
      */
-    public function an_invalid_get_authn_request_is_rejected()
+    public function an_invalid_get_authn_request_is_rejected(): void
     {
         $this->expectExceptionMessage("Redirect binding is supported for SAMLRequest and Response.");
         $this->expectException(\Surfnet\SamlBundle\Exception\InvalidArgumentException::class);

--- a/src/Tests/Unit/Http/HttpBindingFactoryTest.php
+++ b/src/Tests/Unit/Http/HttpBindingFactoryTest.php
@@ -19,13 +19,16 @@
 namespace Surfnet\SamlBundle\Tests\Http;
 
 use Mockery;
-use PHPUnit_Framework_TestCase as UnitTest;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use Surfnet\SamlBundle\Http\HttpBindingFactory;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
-class HttpBindingFactoryTest extends UnitTest
+class HttpBindingFactoryTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /** @var HttpBindingFactory */
     private $factory;
 
@@ -35,7 +38,7 @@ class HttpBindingFactoryTest extends UnitTest
     /** @var ParameterBag|Mockery\Mock */
     private $bag;
 
-    public function setUp()
+    public function setUp(): void
     {
         $redirectBinding = Mockery::mock('\Surfnet\SamlBundle\Http\RedirectBinding');
         $postBinding = Mockery::mock('\Surfnet\SamlBundle\Http\PostBinding');
@@ -44,7 +47,6 @@ class HttpBindingFactoryTest extends UnitTest
         $this->bag = Mockery::mock('\Symfony\Component\HttpFoundation\ParameterBag');
         $this->request->request = $this->bag;
         $this->request->query = $this->bag;
-
     }
 
     /**
@@ -90,11 +92,11 @@ class HttpBindingFactoryTest extends UnitTest
     /**
      * @test
      * @group http
-     * @expectedException \Surfnet\SamlBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Request type of "PUT" is not supported.
      */
     public function a_put_binding_can_not_be_built()
     {
+        $this->expectExceptionMessage("Request type of \"PUT\" is not supported.");
+        $this->expectException(\Surfnet\SamlBundle\Exception\InvalidArgumentException::class);
         $this->request
             ->shouldReceive('getMethod')
             ->andReturn(Request::METHOD_PUT);
@@ -105,11 +107,11 @@ class HttpBindingFactoryTest extends UnitTest
     /**
      * @test
      * @group http
-     * @expectedException \Surfnet\SamlBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage POST-binding is supported for SAMLRequest.
      */
     public function an_invalid_post_authn_request_is_rejected()
     {
+        $this->expectExceptionMessage("POST-binding is supported for SAMLRequest.");
+        $this->expectException(\Surfnet\SamlBundle\Exception\InvalidArgumentException::class);
         $this->request
             ->shouldReceive('getMethod')
             ->andReturn(Request::METHOD_POST);
@@ -125,11 +127,11 @@ class HttpBindingFactoryTest extends UnitTest
     /**
      * @test
      * @group http
-     * @expectedException \Surfnet\SamlBundle\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Redirect binding is supported for SAMLRequest and Response.
      */
     public function an_invalid_get_authn_request_is_rejected()
     {
+        $this->expectExceptionMessage("Redirect binding is supported for SAMLRequest and Response.");
+        $this->expectException(\Surfnet\SamlBundle\Exception\InvalidArgumentException::class);
         $this->request
             ->shouldReceive('getMethod')
             ->andReturn(Request::METHOD_GET);

--- a/src/Tests/Unit/Http/RedirectBindingTest.php
+++ b/src/Tests/Unit/Http/RedirectBindingTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -21,12 +21,13 @@ namespace Surfnet\SamlBundle\Tests\Http;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Entity\ServiceProviderRepository;
 use Surfnet\SamlBundle\Http\Exception\SignatureValidationFailedException;
 use Surfnet\SamlBundle\Http\Exception\UnsignedRequestException;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestQueryString;
 use Surfnet\SamlBundle\Http\RedirectBinding;
+use Surfnet\SamlBundle\Http\RedirectBinding as SamlBundleRedirectBinding;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -35,28 +36,21 @@ class RedirectBindingTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    const ENCODED_MESSAGE = 'fZFfa8IwFMXfBb9DyXvaJtZ1BqsURRC2Mabbw95ivc5Am3TJrXPffmmLY3%2FA15Pzuyf33On8XJXBCaxTRmeEhTEJQBdmr%2FRbRp63K3pL5rPhYOpkVdYib%2FCon%2BC9AYfDQRB4WDvRvWWksVoY6ZQTWlbgBBZik9%2FfCR7GorYGTWFK8pu6DknnwKL%2FWEetlxmR8sBHbHJDWZqOKGdsRJM0kfQAjCUJ43KX8s78ctnIz%2Blp5xpYa4dSo1fjOKGM03i8jSeCMzGevHa2%2FBK5MNo1FdgN2JMqPLmHc0b6WTmiVbsGoTf5qv66Zq2t60x0wXZ2RKydiCJXh3CWVV1CWJgqanfl0%2Bin8xutxYOvZL18NKUqPlvZR5el%2BVhYkAgZQdsA6fWVsZXE63W2itrTQ2cVaKV2CjSSqL1v9P%2FAXv4C';
-    const RAW_MESSAGE = <<<MESSAGE
+    private const ENCODED_MESSAGE = 'fZFfa8IwFMXfBb9DyXvaJtZ1BqsURRC2Mabbw95ivc5Am3TJrXPffmmLY3%2FA15Pzuyf33On8XJXBCaxTRmeEhTEJQBdmr%2FRbRp63K3pL5rPhYOpkVdYib%2FCon%2BC9AYfDQRB4WDvRvWWksVoY6ZQTWlbgBBZik9%2FfCR7GorYGTWFK8pu6DknnwKL%2FWEetlxmR8sBHbHJDWZqOKGdsRJM0kfQAjCUJ43KX8s78ctnIz%2Blp5xpYa4dSo1fjOKGM03i8jSeCMzGevHa2%2FBK5MNo1FdgN2JMqPLmHc0b6WTmiVbsGoTf5qv66Zq2t60x0wXZ2RKydiCJXh3CWVV1CWJgqanfl0%2Bin8xutxYOvZL18NKUqPlvZR5el%2BVhYkAgZQdsA6fWVsZXE63W2itrTQ2cVaKV2CjSSqL1v9P%2FAXv4C';
+    private const RAW_MESSAGE = <<<MESSAGE
 <?xml version="1.0"?>
 <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="aaf23196-1773-2113-474a-fe114412ab72" Version="2.0" IssueInstant="2004-12-05T09:21:59Z" AssertionConsumerServiceIndex="0" AttributeConsumingServiceIndex="0"><saml:Issuer>https://sp.example.com/SAML2</saml:Issuer><samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" AllowCreate="true"/></samlp:AuthnRequest>
 
 MESSAGE;
 
-    /**
-     * @var \Surfnet\SamlBundle\Http\RedirectBinding
-     */
-    private $redirectBinding;
+    private SamlBundleRedirectBinding $redirectBinding;
 
-    /**
-     * @var \Mockery\MockInterface
-     */
-    private $entityRepository;
+    private m\MockInterface|ServiceProviderRepository $entityRepository;
 
     public function setUp(): void
     {
         $this->entityRepository = m::mock('Surfnet\SamlBundle\Entity\ServiceProviderRepository');
         $this->redirectBinding = new RedirectBinding(
-            m::mock('Psr\Log\LoggerInterface'),
             m::mock('Surfnet\SamlBundle\Signing\SignatureVerifier'),
             $this->entityRepository
         );
@@ -66,7 +60,7 @@ MESSAGE;
      * @test
      * @group http
      */
-    public function an_exception_is_thrown_when_the_request_get_parameter_is_not_set()
+    public function an_exception_is_thrown_when_the_request_get_parameter_is_not_set(): void
     {
         $this->expectException(BadRequestHttpException::class);
         $request = m::mock('Symfony\Component\HttpFoundation\Request')
@@ -82,7 +76,7 @@ MESSAGE;
      * @test
      * @group http
      */
-    public function an_exception_is_thrown_when_the_request_is_signed_but_has_no_sigalg_parameter()
+    public function an_exception_is_thrown_when_the_request_is_signed_but_has_no_sigalg_parameter(): void
     {
         $this->expectException(UnsignedRequestException::class);
         $this->expectExceptionMessage(
@@ -111,7 +105,7 @@ MESSAGE;
      *
      * @dataProvider nonGetMethodProvider
      */
-    public function a_signed_authn_request_cannot_be_received_from_a_request_that_is_not_a_get_request($nonGetMethod)
+    public function a_signed_authn_request_cannot_be_received_from_a_request_that_is_not_a_get_request($nonGetMethod): void
     {
         $this->expectException(BadRequestHttpException::class);
         $this->expectExceptionMessage(sprintf('expected a GET method, got %s', $nonGetMethod));
@@ -119,7 +113,7 @@ MESSAGE;
 
         $dummySignatureVerifier = m::mock('\Surfnet\SamlBundle\Signing\SignatureVerifier');
         $dummyEntityRepository  = m::mock('\Surfnet\SamlBundle\Entity\ServiceProviderRepository');
-        $redirectBinding = new RedirectBinding(new NullLogger(), $dummySignatureVerifier, $dummyEntityRepository);
+        $redirectBinding = new RedirectBinding($dummySignatureVerifier, $dummyEntityRepository);
 
         $request = new Request();
         $request->setMethod($nonGetMethod);
@@ -131,7 +125,7 @@ MESSAGE;
      * @test
      * @group http
      */
-    public function a_signed_authn_request_cannot_be_received_from_a_request_that_has_no_signed_saml_request()
+    public function a_signed_authn_request_cannot_be_received_from_a_request_that_has_no_signed_saml_request(): void
     {
         $this->expectException(UnsignedRequestException::class);
         $this->expectExceptionMessage('The SAMLRequest is expected to be signed but it was not');
@@ -143,7 +137,7 @@ MESSAGE;
             . ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . self::ENCODED_MESSAGE;
         $request = new Request([], [], [], [], [], ['REQUEST_URI' => $requestUri]);
 
-        $redirectBinding = new RedirectBinding(new NullLogger(), $dummySignatureVerifier, $dummyEntityRepository);
+        $redirectBinding = new RedirectBinding($dummySignatureVerifier, $dummyEntityRepository);
         $redirectBinding->receiveSignedAuthnRequestFrom($request);
     }
 
@@ -151,7 +145,7 @@ MESSAGE;
      * @test
      * @group http
      */
-    public function a_signed_authn_request_cannot_be_received_if_the_service_provider_in_the_authn_request_is_unknown()
+    public function a_signed_authn_request_cannot_be_received_if_the_service_provider_in_the_authn_request_is_unknown(): void
     {
         $this->expectException('\Surfnet\SamlBundle\Http\Exception\UnknownServiceProviderException');
         $this->expectExceptionMessage('AuthnRequest received from ServiceProvider with an unknown EntityId');
@@ -176,14 +170,14 @@ MESSAGE;
             ->once()
             ->andReturn(true);
 
-        $redirectBinding = new RedirectBinding(new NullLogger(), $dummySignatureVerifier, $mockEntityRepository);
+        $redirectBinding = new RedirectBinding($dummySignatureVerifier, $mockEntityRepository);
         $redirectBinding->receiveSignedAuthnRequestFrom($request);
     }
     /**
      * @test
      * @group http
      */
-    public function a_signed_authn_request_cannot_be_received_if_the_signature_is_invalid()
+    public function a_signed_authn_request_cannot_be_received_if_the_signature_is_invalid(): void
     {
         $this->expectException(SignatureValidationFailedException::class);
         $this->expectExceptionMessage('Validation of the signature in the AuthnRequest failed');
@@ -217,7 +211,7 @@ MESSAGE;
             ->once()
             ->andReturn(false);
 
-        $redirectBinding = new RedirectBinding(new NullLogger(), $mockSignatureVerifier, $mockEntityRepository);
+        $redirectBinding = new RedirectBinding($mockSignatureVerifier, $mockEntityRepository);
         $redirectBinding->receiveSignedAuthnRequestFrom($request);
     }
     /**
@@ -226,14 +220,14 @@ MESSAGE;
      *
      * @dataProvider nonGetMethodProvider
      */
-    public function a_unsigned_authn_request_cannot_be_received_from_a_request_that_is_not_a_get_request($nonGetMethod)
+    public function a_unsigned_authn_request_cannot_be_received_from_a_request_that_is_not_a_get_request($nonGetMethod): void
     {
         $this->expectException('\Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
         $this->expectExceptionMessage(sprintf('expected a GET method, got %s', $nonGetMethod));
 
         $dummySignatureVerifier = m::mock('\Surfnet\SamlBundle\Signing\SignatureVerifier');
         $dummyEntityRepository  = m::mock('\Surfnet\SamlBundle\Entity\ServiceProviderRepository');
-        $redirectBinding = new RedirectBinding(new NullLogger(), $dummySignatureVerifier, $dummyEntityRepository);
+        $redirectBinding = new RedirectBinding($dummySignatureVerifier, $dummyEntityRepository);
 
         $request = new Request();
         $request->setMethod($nonGetMethod);
@@ -245,7 +239,7 @@ MESSAGE;
      * @test
      * @group http
      */
-    public function a_unsigned_authn_request_cannot_be_received_if_the_service_provider_in_the_authn_request_is_unknown()
+    public function a_unsigned_authn_request_cannot_be_received_if_the_service_provider_in_the_authn_request_is_unknown(): void
     {
         $this->expectException('\Surfnet\SamlBundle\Http\Exception\UnknownServiceProviderException');
         $this->expectExceptionMessage('AuthnRequest received from ServiceProvider with an unknown EntityId');
@@ -265,11 +259,11 @@ MESSAGE;
             ->once()
             ->andReturn(false);
 
-        $redirectBinding = new RedirectBinding(new NullLogger(), $dummySignatureVerifier, $dummyEntityRepository);
+        $redirectBinding = new RedirectBinding($dummySignatureVerifier, $dummyEntityRepository);
         $redirectBinding->receiveUnsignedAuthnRequestFrom($request);
     }
 
-    public function nonGetMethodProvider()
+    public function nonGetMethodProvider(): array
     {
         return [
             [Request::METHOD_POST],

--- a/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
+++ b/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
@@ -18,16 +18,20 @@
 
 namespace Surfnet\SamlBundle\Tests;
 
+use Error;
 use Mockery as m;
-use PHPUnit_Framework_TestCase as TestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 
 final class SamlAuthenticationLoggerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @test
      */
-    public function it_returns_a_logger_for_an_authentication()
+    public function it_returns_a_logger_for_an_authentication(): void
     {
         $requestId = md5('boesboes');
 
@@ -41,10 +45,10 @@ final class SamlAuthenticationLoggerTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Surfnet\SamlBundle\Exception\RuntimeException
      */
-    public function it_throws_when_no_authentication()
+    public function it_errors_when_no_authentication(): void
     {
+        $this->expectError(Error::class);
         $logger = new SamlAuthenticationLogger(m::mock('Psr\Log\LoggerInterface'));
         $logger->emergency('message2');
     }

--- a/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
+++ b/src/Tests/Unit/Monolog/SamlAuthenticationLoggerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -48,7 +48,7 @@ final class SamlAuthenticationLoggerTest extends TestCase
      */
     public function it_errors_when_no_authentication(): void
     {
-        $this->expectError(Error::class);
+        $this->expectError();
         $logger = new SamlAuthenticationLogger(m::mock('Psr\Log\LoggerInterface'));
         $logger->emergency('message2');
     }

--- a/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2015 SURFnet B.V.

--- a/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/AttributeDictionaryTest.php
@@ -18,7 +18,8 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Surfnet\SamlBundle\Exception\UnknownUrnException;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 
@@ -28,7 +29,7 @@ class AttributeDictionaryTest extends TestCase
      * @test
      * @group AttributeDictionary
      */
-    public function finds_no_definition_when_no_definition_given()
+    public function finds_no_definition_when_no_definition_given(): void
     {
         $maceAttributeUrn = 'urn:mace:some:attribute';
 
@@ -46,7 +47,7 @@ class AttributeDictionaryTest extends TestCase
      * @test
      * @group AttributeDictionary
      */
-    public function finds_no_definition_when_urn_matches_no_mace_urn()
+    public function finds_no_definition_when_urn_matches_no_mace_urn(): void
     {
         $maceAttributeUrn = 'urn:mace:some:attribute';
         $otherMaceAttributeUrn = 'urn:mace:other:attribute';
@@ -72,7 +73,7 @@ class AttributeDictionaryTest extends TestCase
      * @test
      * @group AttributeDictionary
      */
-    public function finds_no_definition_when_urn_matches_no_oid_urn()
+    public function finds_no_definition_when_urn_matches_no_oid_urn(): void
     {
         $oidAttributeUrn = 'urn:oid:0.0.0.0.0.0.0.0.0';
         $otherOidAttributeUrn = 'urn:oid:0.0.0.0.0.0.0.0.1';
@@ -98,7 +99,7 @@ class AttributeDictionaryTest extends TestCase
      * @test
      * @group AttributeDictionary
      */
-    public function finds_definition_when_urn_matches_urn_mace()
+    public function finds_definition_when_urn_matches_urn_mace(): void
     {
         $maceAttributeUrn = 'urn:mace:some:attribute';
 
@@ -123,7 +124,7 @@ class AttributeDictionaryTest extends TestCase
      * @test
      * @group AttributeDictionary
      */
-    public function finds_definition_when_urn_matches_urn_oid()
+    public function finds_definition_when_urn_matches_urn_oid(): void
     {
         $oidAttributeUrn = 'urn:oid:0.0.0.0.0.0.0.0.0';
 
@@ -147,10 +148,11 @@ class AttributeDictionaryTest extends TestCase
     /**
      * @test
      * @group AttributeDictionary
-     * @expectedException \Surfnet\SamlBundle\Exception\UnknownUrnException
+     *
      */
-    public function shouldThrowExceptionForUnknownAttrib()
+    public function shouldThrowExceptionForUnknownAttrib(): void
     {
+        $this->expectException(UnknownUrnException::class);
         $oidAttributeUrn = 'urn:oid:0.0.0.0.0.0.0.0.0';
 
         $existingOidAttributeDefinition = new AttributeDefinition(
@@ -167,7 +169,7 @@ class AttributeDictionaryTest extends TestCase
      * @test
      * @group AttributeDictionary
      */
-    public function shouldIgnoreUnknownAttributes()
+    public function shouldIgnoreUnknownAttributes(): void
     {
         $attributeDictionary = new AttributeDictionary(true);
         $this->assertTrue($attributeDictionary->ignoreUnknownAttributes());
@@ -177,7 +179,7 @@ class AttributeDictionaryTest extends TestCase
      * @test
      * @group AttributeDictionary
      */
-    public function shouldNotIgnoreUnknownAttributes()
+    public function shouldNotIgnoreUnknownAttributes(): void
     {
         $attributeDictionary = new AttributeDictionary();
         $this->assertFalse($attributeDictionary->ignoreUnknownAttributes());

--- a/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use SAML2\Assertion;
 use stdClass;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
@@ -33,7 +33,7 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      * @group AssertionAdapter
      * @group AttributeSet
      */
-    public function which_attribute_set_is_created_from_a_saml_assertion_is_configurable()
+    public function which_attribute_set_is_created_from_a_saml_assertion_is_configurable(): void
     {
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(self::DUMMY_ATTRIBUTE_SET_CLASS);
         $attributeSet = ConfigurableAttributeSetFactory::createFrom(new Assertion, new AttributeDictionary);
@@ -49,7 +49,7 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      * @group AssertionAdapter
      * @group AttributeSet
      */
-    public function which_attribute_set_is_created_from_attributes_is_configurable()
+    public function which_attribute_set_is_created_from_attributes_is_configurable(): void
     {
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(self::DUMMY_ATTRIBUTE_SET_CLASS);
         $attributeSet = ConfigurableAttributeSetFactory::create([]);
@@ -67,9 +67,10 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      *
      * @dataProvider nonOrEmptyStringProvider()
      */
-    public function the_attribute_set_to_use_can_only_be_represented_as_a_non_empty_string($nonOrEmptyString)
+    public function the_attribute_set_to_use_can_only_be_represented_as_a_non_empty_string($nonOrEmptyString): void
     {
-        $this->setExpectedException('\Surfnet\SamlBundle\Exception\InvalidArgumentException', 'non-empty string');
+        $this->expectException('\Surfnet\SamlBundle\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('non-empty string');
 
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate($nonOrEmptyString);
     }
@@ -79,14 +80,15 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      * @group AssertionAdapter
      * @group AttributeSet
      */
-    public function the_attribute_set_to_use_has_to_implement_attribute_set_factory()
+    public function the_attribute_set_to_use_has_to_implement_attribute_set_factory(): void
     {
-        $this->setExpectedException('\Surfnet\SamlBundle\Exception\InvalidArgumentException', 'implement');
+        $this->expectException('\Surfnet\SamlBundle\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('implement');
 
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate('Non\Existent\Class');
     }
 
-    public function nonOrEmptyStringProvider()
+    public function nonOrEmptyStringProvider(): array
     {
         return [
             'integer'      => [1],

--- a/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/Unit/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2016 SURFnet B.V.
@@ -26,7 +26,7 @@ use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
 
 class ConfigurableAttributeSetFactoryTest extends TestCase
 {
-    const DUMMY_ATTRIBUTE_SET_CLASS = '\Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute\Mock\DummyAttributeSet';
+    private const DUMMY_ATTRIBUTE_SET_CLASS = '\Surfnet\SamlBundle\Tests\Unit\SAML2\Attribute\Mock\DummyAttributeSet';
     
     /**
      * @test

--- a/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
@@ -1,4 +1,20 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2015 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2;
 

--- a/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestFactoryTest.php
@@ -3,8 +3,8 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase as UnitTest;
-use RobRichards\XMLSecLibs\XMLSecurityKey;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use SAML2\Configuration\PrivateKey;
 use Surfnet\SamlBundle\Entity\IdentityProvider;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
@@ -12,17 +12,18 @@ use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
 use Symfony\Component\HttpFoundation\Request;
 
-class AuthnRequestFactoryTest extends UnitTest
+class AuthnRequestFactoryTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @test
      * @group saml2
-     *
-     * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
-     * @expectedExceptionMessage Failed decoding the request, did not receive a valid base64 string
      */
-    public function an_exception_is_thrown_when_a_request_is_not_properly_base64_encoded()
+    public function an_exception_is_thrown_when_a_request_is_not_properly_base64_encoded(): void
     {
+        $this->expectExceptionMessage("Failed decoding the request, did not receive a valid base64 string");
+        $this->expectException(\Surfnet\SamlBundle\Http\Exception\InvalidRequestException::class);
         $invalidCharacter = '$';
         $queryParams      = [AuthnRequest::PARAMETER_REQUEST => $invalidCharacter];
         $serverParams     = [
@@ -36,12 +37,11 @@ class AuthnRequestFactoryTest extends UnitTest
     /**
      * @test
      * @group saml2
-     *
-     * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
-     * @expectedExceptionMessage Failed inflating the request;
      */
-    public function an_exception_is_thrown_when_a_request_cannot_be_inflated()
+    public function an_exception_is_thrown_when_a_request_cannot_be_inflated(): void
     {
+        $this->expectExceptionMessage("Failed inflating the request;");
+        $this->expectException(\Surfnet\SamlBundle\Http\Exception\InvalidRequestException::class);
         $nonDeflated  = base64_encode('nope, not deflated');
         $queryParams  = [AuthnRequest::PARAMETER_REQUEST => $nonDeflated];
         $serverParams = [
@@ -56,7 +56,7 @@ class AuthnRequestFactoryTest extends UnitTest
      * @test
      * @group saml2
      */
-    public function verify_force_authn_works_as_intended()
+    public function verify_force_authn_works_as_intended(): void
     {
         $sp = m::mock(ServiceProvider::class);
         $sp->shouldReceive('getAssertionConsumerUrl')->andReturn('https://example-sp.com/acs');

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -26,10 +26,7 @@ use Surfnet\SamlBundle\SAML2\AuthnRequest;
 
 class AuthnRequestTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $authRequestWithSubject = <<<AUTHNREQUEST_WITH_SUBJECT
+    private string $authRequestWithSubject = <<<AUTHNREQUEST_WITH_SUBJECT
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -45,10 +42,7 @@ class AuthnRequestTest extends TestCase
 </samlp:AuthnRequest>
 AUTHNREQUEST_WITH_SUBJECT;
 
-    /**
-     * @var string
-     */
-    private $authRequestNoSubject = <<<AUTHNREQUEST_NO_SUBJECT
+    private string $authRequestNoSubject = <<<AUTHNREQUEST_NO_SUBJECT
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -61,10 +55,7 @@ AUTHNREQUEST_WITH_SUBJECT;
 </samlp:AuthnRequest>
 AUTHNREQUEST_NO_SUBJECT;
 
-    /**
-     * @var string
-     */
-    private $authRequestIsPassiveFalseAndNoForceAuthnFalse = <<<AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTH_F
+    private string $authRequestIsPassiveFalseAndNoForceAuthnFalse = <<<AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTH_F
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -77,10 +68,7 @@ AUTHNREQUEST_NO_SUBJECT;
 </samlp:AuthnRequest>
 AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTH_F;
 
-    /**
-     * @var string
-     */
-    private $authRequestIsPassiveAndForceAuthnFalse = <<<AUTHNREQUEST_IS_PASSIVE_AND_FORCE_AUTHN_F
+    private string $authRequestIsPassiveAndForceAuthnFalse = <<<AUTHNREQUEST_IS_PASSIVE_AND_FORCE_AUTHN_F
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -94,10 +82,7 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTH_F;
 </samlp:AuthnRequest>
 AUTHNREQUEST_IS_PASSIVE_AND_FORCE_AUTHN_F;
 
-    /**
-     * @var string
-     */
-    private $authRequestIsPassiveFalseAndForceAuthn = <<<AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN
+    private string $authRequestIsPassiveFalseAndForceAuthn = <<<AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -111,10 +96,7 @@ AUTHNREQUEST_IS_PASSIVE_AND_FORCE_AUTHN_F;
 </samlp:AuthnRequest>
 AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
 
-    /**
-     * @var string
-     */
-    private $acsUrl = 'https://example.org';
+    private string $acsUrl = 'https://example.org';
 
     /**
      * @test

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -18,12 +18,13 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2;
 
-use PHPUnit_Framework_TestCase as UnitTest;
+use PHPUnit\Framework\TestCase;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\DOMDocumentFactory;
+use SAML2\XML\saml\NameID;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 
-class AuthnRequestTest extends UnitTest
+class AuthnRequestTest extends TestCase
 {
     /**
      * @var string
@@ -116,24 +117,11 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
     private $acsUrl = 'https://example.org';
 
     /**
-     * @var string
-     */
-    private $nameId = 'user@example.org';
-
-    /**
-     * @var string
-     */
-    private $format = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
-
-    /**
      * @test
      * @group saml2
      * @dataProvider provideNameIDAndFormatCombinations
-     *
-     * @param $nameId
-     * @param $format
      */
-    public function setting_the_subject_generates_valid_xml($nameId, $format)
+    public function setting_the_subject_generates_valid_xml(string $nameId, ?string $format): void
     {
         $domDocument = DOMDocumentFactory::fromString($this->authRequestNoSubject);
         $request     = new SAML2AuthnRequest($domDocument->documentElement);
@@ -148,22 +136,26 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
      * @test
      * @group saml2
      */
-    public function the_nameid_and_format_can_be_retrieved_from_the_authnrequest()
+    public function the_nameid_and_format_can_be_retrieved_from_the_authnrequest(): void
     {
         $domDocument = DOMDocumentFactory::fromString($this->authRequestWithSubject);
         $request     = new SAML2AuthnRequest($domDocument->documentElement);
 
         $authnRequest = AuthnRequest::createNew($request);
 
-        $this->assertEquals($this->nameId, $authnRequest->getNameId());
-        $this->assertEquals($this->format, $authnRequest->getNameIdFormat());
+        $nameId = new NameID();
+        $nameId->setValue('user@example.org');
+        $nameId->setFormat('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified');
+
+        $this->assertEquals($nameId->getValue(), $authnRequest->getNameId());
+        $this->assertEquals($nameId->getFormat(), $authnRequest->getNameIdFormat());
     }
 
     /**
      * @test
      * @group saml2
      */
-    public function the_acs_url_can_be_retrieved_from_the_authnrequest()
+    public function the_acs_url_can_be_retrieved_from_the_authnrequest(): void
     {
         $domDocument = DOMDocumentFactory::fromString($this->authRequestWithSubject);
         $request     = new SAML2AuthnRequest($domDocument->documentElement);
@@ -172,7 +164,6 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
 
         $this->assertEquals($this->acsUrl, $authnRequest->getAssertionConsumerServiceURL());
     }
-
 
     /**
      * @test
@@ -183,7 +174,7 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
      * @param bool   $isPassive
      * @param bool   $forceAuthn
      */
-    public function is_passive_and_force_authn_can_be_retrieved_from_the_authnrequest($xml, $isPassive, $forceAuthn)
+    public function is_passive_and_force_authn_can_be_retrieved_from_the_authnrequest($xml, $isPassive, $forceAuthn): void
     {
         $domDocument = DOMDocumentFactory::fromString($xml);
         $request     = new SAML2AuthnRequest($domDocument->documentElement);
@@ -193,7 +184,7 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
         $this->assertEquals($forceAuthn, $authnRequest->isForceAuthn());
     }
 
-    public function provideIsPassiveAndForceAuthnCombinations()
+    public function provideIsPassiveAndForceAuthnCombinations(): array
     {
         return [
             'isPassive false and ForceAuthn false' => [$this->authRequestIsPassiveFalseAndNoForceAuthnFalse, false, false],
@@ -202,11 +193,15 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
         ];
     }
 
-    public function provideNameIDAndFormatCombinations()
+    public function provideNameIDAndFormatCombinations(): array
     {
+        $nameId = new NameID();
+        $nameId->setValue('user@example.org');
+        $nameId->setFormat('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified');
+
         return [
-            'NameID without Format' => [$this->nameId, null],
-            'NameID with Format'    => [$this->nameId, $this->format]
+            'NameID without Format' => [$nameId->getValue(), null],
+            'NameID with Format'    => [$nameId->getValue(), $nameId->getFormat()]
         ];
     }
 }

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
@@ -18,7 +18,8 @@
 
 namespace Tests\Unit\SAML2;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Surfnet\SamlBundle\Http\Exception\InvalidRequestException;
 use Surfnet\SamlBundle\Http\ReceivedAuthnRequestPost;
 
 class ReceivedAuthnRequestPostTest extends TestCase
@@ -26,7 +27,7 @@ class ReceivedAuthnRequestPostTest extends TestCase
     /**
      * @test
      */
-    public function it_can_decode_a_signed_saml_request()
+    public function it_can_decode_a_signed_saml_request(): void
     {
         $samlRequest = str_replace(PHP_EOL, '', file_get_contents(__DIR__ . '/Resources/valid-signed.xml'));
         $parameters = [
@@ -40,20 +41,21 @@ class ReceivedAuthnRequestPostTest extends TestCase
     /**
      * @test
      */
-    public function it_can_decode_a_signed_saml_request_from_adfs_origin()
+    public function it_can_decode_a_signed_saml_request_from_adfs_origin(): void
     {
         $samlRequest = str_replace(PHP_EOL, '', file_get_contents(__DIR__ . '/Resources/valid-signed-adfs.xml'));
         $parameters = [
             'SAMLRequest' => base64_encode($samlRequest),
             'RelayState' => '/index.php',
         ];
-        ReceivedAuthnRequestPost::parse($parameters);
+        $parsed = ReceivedAuthnRequestPost::parse($parameters);
+        $this->assertInstanceOf(ReceivedAuthnRequestPost::class, $parsed);
     }
 
     /**
      * @test
      */
-    public function it_can_decode_an_usigned_saml_request()
+    public function it_can_decode_an_usigned_saml_request(): void
     {
         $samlRequest = str_replace(PHP_EOL, '', file_get_contents(__DIR__ . '/Resources/valid-unsigned.xml'));
         $parameters = [
@@ -66,11 +68,11 @@ class ReceivedAuthnRequestPostTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
-     * @expectedExceptionMessage Failed decoding SAML request, did not receive a valid base64 string
      */
-    public function it_rejects_malformed_saml_request()
+    public function it_rejects_malformed_saml_request(): void
     {
+        $this->expectExceptionMessage("Failed decoding SAML request, did not receive a valid base64 string");
+        $this->expectException(InvalidRequestException::class);
         $parameters = [
             'SAMLRequest' => 'this=notvalid==',
             'RelayState' => '/index.php',

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestPostTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2017 SURFnet B.V.

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
@@ -18,7 +18,7 @@
 
 namespace Tests\Unit\SAML2;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use SAML2\AuthnRequest as SAML2AuthnRequest;
 use SAML2\DOMDocumentFactory;
 use stdClass;
@@ -49,12 +49,10 @@ AUTHNREQUEST_NO_SUBJECT;
      * @dataProvider nonOrEmptyStringProvider
      * @param $nonOrEmptyString
      */
-    public function a_received_authn_request_query_string_cannot_be_parsed_from_non_or_empty_strings($nonOrEmptyString)
+    public function a_received_authn_request_query_string_cannot_be_parsed_from_non_or_empty_strings($nonOrEmptyString): void
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'expected a non-empty string'
-        );
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
+        $this->expectExceptionMessage('expected a non-empty string');
 
         ReceivedAuthnRequestQueryString::parse($nonOrEmptyString);
     }
@@ -63,12 +61,10 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_received_authn_request_query_string_must_contain_valid_key_value_pairs()
+    public function a_received_authn_request_query_string_must_contain_valid_key_value_pairs(): void
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'does not contain a valid key-value pair'
-        );
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
+        $this->expectExceptionMessage('does not contain a valid key-value pair');
 
         ReceivedAuthnRequestQueryString::parse('a-key-without-a-value');
     }
@@ -77,12 +73,10 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_received_authn_request_query_string_must_contain_a_base64_encoded_saml_request()
+    public function a_received_authn_request_query_string_must_contain_a_base64_encoded_saml_request(): void
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidRequestException',
-            'did not receive a valid base64 string'
-        );
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidRequestException');
+        $this->expectExceptionMessage('did not receive a valid base64 string');
 
         $notEncodedRequest = 'non-encoded-string';
 
@@ -101,11 +95,9 @@ AUTHNREQUEST_NO_SUBJECT;
      */
     public function a_received_authn_request_query_string_cannot_contain_a_saml_parameter_twice(
         $doubleParameterName, $queryStringWithDoubleParameter
-    ) {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            sprintf('parameter "%s" already present', $doubleParameterName)
-        );
+    ): void {
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
+        $this->expectExceptionMessage(sprintf('parameter "%s" already present', $doubleParameterName));
 
         ReceivedAuthnRequestQueryString::parse($queryStringWithDoubleParameter);
     }
@@ -114,12 +106,10 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_received_authn_request_query_string_must_contain_a_saml_request()
+    public function a_received_authn_request_query_string_must_contain_a_saml_request(): void
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            sprintf('parameter "%s" not found', ReceivedAuthnRequestQueryString::PARAMETER_REQUEST)
-        );
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
+        $this->expectExceptionMessage(sprintf('parameter "%s" not found', ReceivedAuthnRequestQueryString::PARAMETER_REQUEST));
 
         $queryStringWithoutSamlRequest = 
             '?' . ReceivedAuthnRequestQueryString::PARAMETER_SIGNATURE . '=' . urlencode(base64_encode('signature'))
@@ -132,12 +122,10 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_received_authn_request_query_string_cannot_contain_a_signature_algorithm_without_a_signature()
+    public function a_received_authn_request_query_string_cannot_contain_a_signature_algorithm_without_a_signature(): void
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'contains a signature algorithm but not a signature'
-        );
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
+        $this->expectExceptionMessage('contains a signature algorithm but not a signature');
 
         $queryStringWithSignatureAlgorithmWithoutSignature =
             '?' . ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . urlencode(base64_encode('saml-request'))
@@ -150,12 +138,10 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_received_authn_request_query_string_cannot_contain_a_signature_without_a_signature_algorithm()
+    public function a_received_authn_request_query_string_cannot_contain_a_signature_without_a_signature_algorithm(): void
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'contains a signature but not a signature algorithm'
-        );
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
+        $this->expectExceptionMessage('contains a signature but not a signature algorithm');
 
         $queryStringWithSignatureWithoutSignatureAlgorithm =
             '?' . ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . urlencode(base64_encode('saml-request'))
@@ -168,12 +154,10 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_received_authn_request_query_string_cannot_contain_a_signature_that_is_not_properly_base64_encoded()
+    public function a_received_authn_request_query_string_cannot_contain_a_signature_that_is_not_properly_base64_encoded(): void
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException',
-            'signature is not base64 encoded correctly'
-        );
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
+        $this->expectExceptionMessage('signature is not base64 encoded correctly');
 
         $queryStringWithSignatureWithoutSignatureAlgorithm =
             '?' . ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . urlencode(base64_encode('saml-request'))
@@ -187,7 +171,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_signed_query_string_can_be_acquired_from_a_received_authn_request_query_string()
+    public function a_signed_query_string_can_be_acquired_from_a_received_authn_request_query_string(): void
     {
         $expectedSignedQueryString = ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . urlencode(base64_encode('saml-request'))
             . '&' . ReceivedAuthnRequestQueryString::PARAMETER_RELAY_STATE . '=relay-state'
@@ -206,7 +190,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function query_parameters_that_are_not_used_for_a_saml_message_are_ignored_when_creating_a_signed_query_string()
+    public function query_parameters_that_are_not_used_for_a_saml_message_are_ignored_when_creating_a_signed_query_string(): void
     {
         $arbitraryParameterToIgnore = 'arbitraryParameter=this-should-be-ignored';
 
@@ -231,7 +215,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_decoded_signature_can_be_acquired_from_a_received_authn_request_query_string()
+    public function a_decoded_signature_can_be_acquired_from_a_received_authn_request_query_string(): void
     {
         $signature = 'signature';
 
@@ -255,7 +239,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_decoded_saml_request_can_be_acquired_from_a_received_authn_request_query_string()
+    public function a_decoded_saml_request_can_be_acquired_from_a_received_authn_request_query_string(): void
     {
         $domDocument          = DOMDocumentFactory::fromString($this->authRequestNoSubject);
         $unsignedAuthnRequest = SAML2AuthnRequest::fromXML($domDocument->firstChild);
@@ -279,12 +263,10 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function a_saml_request_cannot_be_decoded_from_a_received_authn_request_query_string_if_it_was_not_properly_gzipped()
+    public function a_saml_request_cannot_be_decoded_from_a_received_authn_request_query_string_if_it_was_not_properly_gzipped(): void
     {
-        $this->setExpectedException(
-            '\Surfnet\SamlBundle\Http\Exception\InvalidRequestException',
-            'Failed inflating SAML Request'
-        );
+        $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidRequestException');
+        $this->expectExceptionMessage('Failed inflating SAML Request');
 
         $notGzippedRequest = urlencode(base64_encode('this-is-not-gzipped'));
 
@@ -298,7 +280,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      */
-    public function parameters_can_be_queried_from_the_received_authn_request_query()
+    public function parameters_can_be_queried_from_the_received_authn_request_query(): void
     {
         $samlRequest = urlencode(base64_encode('encoded-saml-request'));
         $relayState = 'relay-state';
@@ -334,10 +316,7 @@ AUTHNREQUEST_NO_SUBJECT;
         );
     }
 
-    /**
-     * @return array
-     */
-    public function nonOrEmptyStringProvider()
+    public function nonOrEmptyStringProvider(): array
     {
         return [
             'empty string' => [''],
@@ -350,10 +329,7 @@ AUTHNREQUEST_NO_SUBJECT;
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function queryStringWithRepeatedSamlParametersProvider()
+    public function queryStringWithRepeatedSamlParametersProvider(): array
     {
         $queryString = $queryString = ReceivedAuthnRequestQueryString::PARAMETER_REQUEST . '=' . urlencode(base64_encode('saml-request'))
             . '&' . ReceivedAuthnRequestQueryString::PARAMETER_RELAY_STATE . '=relay-state'

--- a/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
+++ b/src/Tests/Unit/SAML2/ReceivedAuthnRequestQueryStringTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2017 SURFnet B.V.
@@ -26,10 +26,7 @@ use Surfnet\SamlBundle\Http\ReceivedAuthnRequestQueryString;
 
 class ReceivedAuthnRequestQueryStringTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $authRequestNoSubject = <<<AUTHNREQUEST_NO_SUBJECT
+    private string $authRequestNoSubject = <<<AUTHNREQUEST_NO_SUBJECT
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -46,14 +43,27 @@ AUTHNREQUEST_NO_SUBJECT;
      * @test
      * @group AuthnRequest
      *
-     * @dataProvider nonOrEmptyStringProvider
+     * @dataProvider emptyStringProvider
      * @param $nonOrEmptyString
      */
-    public function a_received_authn_request_query_string_cannot_be_parsed_from_non_or_empty_strings($nonOrEmptyString): void
+    public function a_received_authn_request_query_string_cannot_be_parsed_from_empty_strings($nonOrEmptyString): void
     {
         $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
         $this->expectExceptionMessage('expected a non-empty string');
 
+        ReceivedAuthnRequestQueryString::parse($nonOrEmptyString);
+    }
+
+    /**
+     * @test
+     * @group AuthnRequest
+     *
+     * @dataProvider nonStringProvider
+     * @param $nonOrEmptyString
+     */
+    public function a_received_authn_request_query_string_cannot_be_parsed_from_non_strings($nonOrEmptyString): void
+    {
+        $this->expectError();
         ReceivedAuthnRequestQueryString::parse($nonOrEmptyString);
     }
 
@@ -94,7 +104,7 @@ AUTHNREQUEST_NO_SUBJECT;
      * @param $queryStringWithDoubleParameter
      */
     public function a_received_authn_request_query_string_cannot_contain_a_saml_parameter_twice(
-        $doubleParameterName, $queryStringWithDoubleParameter
+        string $doubleParameterName, string $queryStringWithDoubleParameter
     ): void {
         $this->expectException('\Surfnet\SamlBundle\Http\Exception\InvalidReceivedAuthnRequestQueryStringException');
         $this->expectExceptionMessage(sprintf('parameter "%s" already present', $doubleParameterName));
@@ -316,11 +326,16 @@ AUTHNREQUEST_NO_SUBJECT;
         );
     }
 
-    public function nonOrEmptyStringProvider(): array
+    public function emptyStringProvider(): array
     {
         return [
             'empty string' => [''],
-            'string with spaces' => ['   '],
+            'string with spaces' => ['   ']
+        ];
+    }
+    public function nonStringProvider(): array
+    {
+        return [
             'integer' => [123],
             'float' => [1.23],
             'object' => [new stdClass()],

--- a/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2015 SURFnet B.V.

--- a/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/AssertionAdapterTest.php
@@ -19,7 +19,8 @@
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Response\Assertion;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase as TestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
@@ -27,11 +28,13 @@ use Surfnet\SamlBundle\SAML2\Response\AssertionAdapter;
 
 class AssertionAdapterTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @test
      * @group AssertionAdapter
      */
-    public function presence_of_attribute_can_be_confirmed_based_on_mace_urn_attribute_definition()
+    public function presence_of_attribute_can_be_confirmed_based_on_mace_urn_attribute_definition(): void
     {
 
         $maceAttributeUrn   = 'urn:mace:some:attribute';
@@ -61,7 +64,7 @@ class AssertionAdapterTest extends TestCase
      * @test
      * @group AssertionAdapter
      */
-    public function presence_of_attribute_can_be_confirmed_based_on_oid_urn_attribute_definition()
+    public function presence_of_attribute_can_be_confirmed_based_on_oid_urn_attribute_definition(): void
     {
         $oidAttributeUrn   = 'urn:oid:0.0.0.0.0.0.0.0.0';
         $oidAttributeValue = ['oid-attribute-value'];
@@ -89,11 +92,10 @@ class AssertionAdapterTest extends TestCase
     /**
      * @test
      * @group AssertionAdapter
-     *
-     * @expectedException \Surfnet\SamlBundle\Exception\UnknownUrnException
      */
-    public function no_presence_of_attribute_can_be_confirmed_if_no_attribute_definition_found()
+    public function no_presence_of_attribute_can_be_confirmed_if_no_attribute_definition_found(): void
     {
+        $this->expectException(\Surfnet\SamlBundle\Exception\UnknownUrnException::class);
         $oidAttributeUrn   = 'urn:oid:0.0.0.0.0.0.0.0.0';
         $oidAttributeValue = ['oid-attribute-value'];
         $existingOidAttributeDefinition = new AttributeDefinition(
@@ -119,7 +121,7 @@ class AssertionAdapterTest extends TestCase
      * @test
      * @group AssertionAdapter
      */
-    public function attribute_set_is_empty_if_no_attributes_found()
+    public function attribute_set_is_empty_if_no_attributes_found(): void
     {
         $assertion = m::mock('\\SAML2\\Assertion');
         $assertion->shouldReceive('getAttributes')->andReturn([]);
@@ -136,7 +138,7 @@ class AssertionAdapterTest extends TestCase
      * @test
      * @group AssertionAdapter
      */
-    public function attribute_set_has_content_when_attributes_found()
+    public function attribute_set_has_content_when_attributes_found(): void
     {
         $oidAttributeUrn   = 'urn:oid:0.0.0.0.0.0.0.0.0';
         $oidAttributeValue = ['oid-attribute-value'];
@@ -162,7 +164,7 @@ class AssertionAdapterTest extends TestCase
      * @test
      * @group AssertionAdapter
      */
-    public function attribute_set_has_no_duplicate_attribute_definitions_when_same_attributes_found()
+    public function attribute_set_has_no_duplicate_attribute_definitions_when_same_attributes_found(): void
     {
         $oidAttributeUrn   = 'urn:oid:0.0.0.0.0.0.0.0.0';
         $maceAttributeUrn   = 'urn:mace:some:attribute';

--- a/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
@@ -18,13 +18,13 @@
 
 namespace Surfnet\SamlBundle\Tests\Unit\SAML2\Response\Assertion;
 
-use PHPUnit_Framework_TestCase as UnitTest;
+use PHPUnit\Framework\TestCase;
 use SAML2\Assertion;
 use SAML2\XML\saml\SubjectConfirmation;
 use SAML2\XML\saml\SubjectConfirmationData;
 use Surfnet\SamlBundle\SAML2\Response\Assertion\InResponseTo;
 
-class InResponseToTest extends UnitTest
+class InResponseToTest extends TestCase
 {
     /**
      * @param Assertion $assertion
@@ -34,7 +34,7 @@ class InResponseToTest extends UnitTest
      * @group saml2
      * @dataProvider provideAssertionsWithoutInResponseTo
      */
-    public function assertions_without_in_response_to_are_tested_as_if_in_response_to_is_null(Assertion $assertion)
+    public function assertions_without_in_response_to_are_tested_as_if_in_response_to_is_null(Assertion $assertion): void
     {
         $this->assertTrue(InResponseTo::assertEquals($assertion, null));
         $this->assertFalse(InResponseTo::assertEquals($assertion, 'some not-null-value'));
@@ -45,23 +45,20 @@ class InResponseToTest extends UnitTest
      * @group saml2-response
      * @group saml2
      */
-    public function in_reponse_to_equality_is_strictly_checked()
+    public function in_reponse_to_equality_is_strictly_checked(): void
     {
         $assertion                   = new Assertion();
         $subjectConfirmationWithData = new SubjectConfirmation();
         $subjectConfirmationData     = new SubjectConfirmationData();
-        $subjectConfirmationData->InResponseTo = '1';
-        $subjectConfirmationWithData->SubjectConfirmationData = $subjectConfirmationData;
+        $subjectConfirmationData->setInResponseTo('1');
+        $subjectConfirmationWithData->setSubjectConfirmationData($subjectConfirmationData);
         $assertion->setSubjectConfirmation([$subjectConfirmationWithData]);
 
         $this->assertTrue(InResponseTo::assertEquals($assertion, '1'));
         $this->assertFalse(InResponseTo::assertEquals($assertion, 1));
     }
 
-    /**
-     * @return array
-     */
-    public function provideAssertionsWithoutInResponseTo()
+    public function provideAssertionsWithoutInResponseTo(): array
     {
         $assertionWithoutSubjectConfirmation = new Assertion();
 
@@ -71,7 +68,7 @@ class InResponseToTest extends UnitTest
 
         $assertionWithEmptyInResponseTo = new Assertion();
         $subjectConfirmationWithData = new SubjectConfirmation();
-        $subjectConfirmationWithData->SubjectConfirmationData = new SubjectConfirmationData();
+        $subjectConfirmationWithData->setSubjectConfirmationData(new SubjectConfirmationData());
         $assertionWithEmptyInResponseTo->setSubjectConfirmation([$subjectConfirmationWithData]);
 
         return [

--- a/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
+++ b/src/Tests/Unit/SAML2/Response/Assertion/InResponseToTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2014 SURFnet bv
@@ -27,8 +27,6 @@ use Surfnet\SamlBundle\SAML2\Response\Assertion\InResponseTo;
 class InResponseToTest extends TestCase
 {
     /**
-     * @param Assertion $assertion
-     *
      * @test
      * @group saml2-response
      * @group saml2

--- a/src/Tests/Unit/Security/FakeAuthencationStateHandler.php
+++ b/src/Tests/Unit/Security/FakeAuthencationStateHandler.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Tests\Unit\Security;
+
+use Surfnet\SamlBundle\Security\Authentication\SamlAuthenticationStateHandler;
+
+class FakeAuthencationStateHandler implements SamlAuthenticationStateHandler
+{
+    private string $requestId = '';
+
+    public static function createWithRequestId(string $requestId): self
+    {
+        $stateHandler = new self;
+        $stateHandler->requestId = $requestId;
+        return $stateHandler;
+    }
+
+    public static function createWithoutRequestId(): self
+    {
+        return new self;
+    }
+
+    public function getRequestId(): string
+    {
+        return $this->requestId;
+    }
+
+    public function setRequestId(string $requestId): void
+    {
+        $this->requestId = $requestId;
+    }
+
+    public function hasRequestId(): bool
+    {
+        return $this->requestId !== '';
+    }
+
+    public function clearRequestId(): void
+    {
+        $this->requestId = '';
+    }
+}

--- a/src/Tests/Unit/Security/SamlAuthenticatorTest.php
+++ b/src/Tests/Unit/Security/SamlAuthenticatorTest.php
@@ -53,18 +53,18 @@ class SamlAuthenticatorTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private readonly SamlAuthenticator $authenticator;
-    private readonly IdentityProvider $idp;
-    private readonly ServiceProvider $sp;
-    private readonly RedirectBinding $redirectBinding;
-    private readonly SamlAuthenticationStateHandler $samlAuthenticationStateHandler;
-    private readonly ProcessSamlAuthenticationHandler $processSamlAuthenticationHandler;
-    private readonly AuthenticationSuccessHandlerInterface $successHandler;
-    private readonly AuthenticationFailureHandlerInterface $failureHandler;
-    private readonly SamlProviderInterface $samlProvider;
-    private readonly RouterInterface $router;
-    private readonly LoggerInterface $logger;
-    private readonly string $acsRouteName;
+    private SamlAuthenticator $authenticator;
+    private IdentityProvider $idp;
+    private ServiceProvider $sp;
+    private RedirectBinding $redirectBinding;
+    private SamlAuthenticationStateHandler $samlAuthenticationStateHandler;
+    private ProcessSamlAuthenticationHandler $processSamlAuthenticationHandler;
+    private AuthenticationSuccessHandlerInterface $successHandler;
+    private AuthenticationFailureHandlerInterface $failureHandler;
+    private SamlProviderInterface $samlProvider;
+    private RouterInterface $router;
+    private LoggerInterface $logger;
+    private string $acsRouteName;
 
     protected function setUp(): void
     {

--- a/src/Tests/Unit/Security/SamlAuthenticatorTest.php
+++ b/src/Tests/Unit/Security/SamlAuthenticatorTest.php
@@ -1,0 +1,222 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Tests\Unit\Security;
+
+use Generator;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use SAML2\Assertion;
+use SAML2\Configuration\PrivateKey;
+use Surfnet\SamlBundle\Security\Authentication\Handler\FailureHandler;
+use Surfnet\SamlBundle\Security\Authentication\Handler\SuccessHandler;
+use Surfnet\SamlBundle\Security\Authentication\Passport\Badge\SamlAttributesBadge;
+use Surfnet\SamlBundle\Security\Authentication\SamlAuthenticationStateHandler;
+use Surfnet\SamlBundle\Security\Authentication\SamlAuthenticator;
+use Psr\Log\LoggerInterface;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Http\RedirectBinding;
+use Surfnet\SamlBundle\Security\Authentication\Handler\ProcessSamlAuthenticationHandler;
+use Surfnet\SamlBundle\Security\Authentication\Provider\SamlProviderInterface;
+use Surfnet\SamlBundle\Security\Authentication\Token\SamlToken;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+class SamlAuthenticatorTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private readonly SamlAuthenticator $authenticator;
+    private readonly IdentityProvider $idp;
+    private readonly ServiceProvider $sp;
+    private readonly RedirectBinding $redirectBinding;
+    private readonly SamlAuthenticationStateHandler $samlAuthenticationStateHandler;
+    private readonly ProcessSamlAuthenticationHandler $processSamlAuthenticationHandler;
+    private readonly AuthenticationSuccessHandlerInterface $successHandler;
+    private readonly AuthenticationFailureHandlerInterface $failureHandler;
+    private readonly SamlProviderInterface $samlProvider;
+    private readonly RouterInterface $router;
+    private readonly LoggerInterface $logger;
+    private readonly string $acsRouteName;
+
+    protected function setUp(): void
+    {
+        $this->idp = Mockery::mock(IdentityProvider::class);
+        $this->sp = Mockery::mock(ServiceProvider::class);
+        $this->redirectBinding = Mockery::mock(RedirectBinding::class);
+        $this->samlAuthenticationStateHandler = Mockery::mock(SamlAuthenticationStateHandler::class);
+        $this->processSamlAuthenticationHandler = Mockery::mock(ProcessSamlAuthenticationHandler::class);
+        $this->successHandler = Mockery::mock(SuccessHandler::class);
+        $this->failureHandler = Mockery::mock(FailureHandler::class);
+        $this->samlProvider = Mockery::mock(SamlProviderInterface::class);
+        $this->router = Mockery::mock(RouterInterface::class);
+        $this->logger = Mockery::mock(LoggerInterface::class);
+        $this->acsRouteName = 'route-name';
+
+        $this->authenticator = new SamlAuthenticator(
+            $this->idp,
+            $this->sp,
+            $this->redirectBinding,
+            $this->samlAuthenticationStateHandler,
+            $this->processSamlAuthenticationHandler,
+            $this->successHandler,
+            $this->failureHandler,
+            $this->samlProvider,
+            $this->router,
+            $this->logger,
+            $this->acsRouteName
+        );
+    }
+
+    public function test_start(): void
+    {
+        $request = Mockery::mock(Request::class);
+
+        $privateKey = Mockery::mock(PrivateKey::class);
+        $privateKey->shouldReceive('isFile')->andReturnFalse();
+        $privateKey->shouldReceive('getContents')->andReturn('pk-contents');
+        $privateKey->shouldReceive('getPassPhrase')->andReturn('');
+        $this->sp->shouldReceive('getAssertionConsumerUrl')->andReturn('route-name');
+        $this->sp->shouldReceive('getEntityId')->andReturn('https://sp-entity-id');
+        $this->sp->shouldReceive('getPrivateKey')->andReturn($privateKey);
+
+        $this->idp->shouldReceive('getSsoUrl')->andReturn('idp-sso');
+
+        $this->samlAuthenticationStateHandler->shouldReceive('setRequestId')->with('1');
+
+        $this->redirectBinding->shouldReceive('createResponseFor')->andReturn(Mockery::mock(RedirectResponse::class));
+
+        $response = $this->authenticator->start($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    /**
+     * @dataProvider provideSupportsParameters
+     */
+    public function test_supports($expectedResult, $post, $server, $routeName): void
+    {
+        $request = new Request([], $post, [], [], [], $server);
+        $this->router->shouldReceive('generate')->with('route-name')->andReturn($routeName);
+        $this->assertEquals($expectedResult, $this->authenticator->supports($request));
+    }
+
+    public function provideSupportsParameters(): Generator
+    {
+        yield [true, ['SAMLResponse' => 'foobar'], ['REQUEST_URI' => '/route-name', 'REQUEST_METHOD' => 'POST'], '/route-name'];
+        yield [false, ['SAMLRespons' => 'foobar'], ['REQUEST_URI' => '/route-name', 'REQUEST_METHOD' => 'POST'], '/route-name'];
+        yield [false, ['SAMLResponse' => 'foobar'], ['REQUEST_URL' => '/route-name', 'REQUEST_METHOD' => 'POST'], '/route-name'];
+        yield [false, ['SAMLResponse' => 'foobar'], ['REQUEST_URI' => '/route-name', 'REQUEST_METHOD' => 'OPTIONS'], '/route-name'];
+        yield [false, ['SAMLResponse' => 'foobar'], ['REQUEST_URI' => '/route-name', 'REQUEST_METHOD' => 'POST'], '/route'];
+    }
+
+    public function test_authenticate(): void
+    {
+        $server = ['REQUEST_URI' => '/route-name', 'REQUEST_METHOD' => 'POST'];
+        $assertion = $this->assertion();
+        $request = new Request([], ['SAMLResponse' => 'foobar'], [], [], [], $server);
+        // The `process` method performs the actual authentication procedure.
+        // See tests for that method in the corresponding unit test
+        $this->processSamlAuthenticationHandler->shouldReceive('process')->andReturn($assertion);
+        $this->samlProvider->shouldReceive('getNameId')->with($assertion)->andReturn('john-doe');
+        $this->logger->shouldReceive('notice')->with('Successfully processed SAMLResponse, attempting to authenticate');
+
+        $passport = $this->authenticator->authenticate($request);
+        $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
+
+        $userBadge = $passport->getBadge(UserBadge::class);
+        $attributesBadge = $passport->getBadge(SamlAttributesBadge::class);
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
+        $this->assertInstanceOf(SamlAttributesBadge::class, $attributesBadge);
+
+        $this->assertTrue($userBadge->isResolved());
+
+        $this->assertEquals([['attr1' => 'attr 1 value', 'attr2' => 'attr 2 value']], $attributesBadge->getAttributes());
+        $this->assertTrue($attributesBadge->isResolved());
+    }
+
+    private function assertion(): Assertion
+    {
+        $assertion = new Assertion();
+        $assertion->setAttributes([['attr1' => 'attr 1 value', 'attr2' => 'attr 2 value']]);
+        return $assertion;
+    }
+
+    public function test_create_token(): void
+    {
+        $user = Mockery::mock(UserInterface::class);
+        $user->shouldReceive('getRoles')->andReturn(['ROLE_ADMINISTRATOR']);
+
+        $badge = Mockery::mock(BadgeInterface::class);
+        $badge->shouldReceive('getAttributes')->andReturn([]);
+
+        $passport = Mockery::mock(SelfValidatingPassport::class);
+        $passport->shouldReceive('hasBadge')->andReturnTrue();
+        $passport->shouldReceive('getBadge')->andReturn($badge);
+        $passport->shouldReceive('getUser')->andReturn($user);
+        $token = $this->authenticator->createToken($passport, 'smal_based');
+        $this->assertInstanceOf(SamlToken::class, $token);
+    }
+
+    public function test_on_success(): void
+    {
+        $request = Mockery::mock(Request::class);
+        $token = Mockery::mock(TokenInterface::class);
+
+        $user = Mockery::mock(UserInterface::class);
+        $user->shouldReceive('getUserIdentifier')->andReturn('john_doe');
+        $token->shouldReceive('getUser')->andReturn($user);
+
+        $redirectResponse = Mockery::mock(RedirectResponse::class);
+        $this->successHandler->shouldReceive('onAuthenticationSuccess')->andReturn($redirectResponse);
+
+        $firewall = 'saml_based';
+        $this->logger->shouldReceive('notice');
+        $this->samlAuthenticationStateHandler->shouldReceive('clearRequestId');
+
+        $response = $this->authenticator->onAuthenticationSuccess($request, $token, $firewall);
+        $this->assertEquals($response, $redirectResponse);
+    }
+
+    public function test_on_failure(): void
+    {
+        $request = Mockery::mock(Request::class);
+        $exception = Mockery::mock(AuthenticationException::class);
+        $failedResponse = Mockery::mock(Response::class);
+        $this->failureHandler->shouldReceive('onAuthenticationFailure')->with($request, $exception)->andReturn($failedResponse);
+        $response = $this->authenticator->onAuthenticationFailure($request, $exception);
+        $this->assertEquals($response, $failedResponse);
+    }
+
+    public function test_is_interactive(): void
+    {
+        $this->assertTrue($this->authenticator->isInteractive());
+    }
+}

--- a/src/Tests/Unit/Security/SamlInteractionProviderTest.php
+++ b/src/Tests/Unit/Security/SamlInteractionProviderTest.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Security\Authentication;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use SAML2\Assertion;
+use SAML2\Configuration\PrivateKey;
+use SAML2\XML\saml\Issuer;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Http\PostBinding;
+use Surfnet\SamlBundle\Http\RedirectBinding;
+use Surfnet\SamlBundle\Security\Exception\UnexpectedIssuerException;
+use Surfnet\SamlBundle\Tests\Unit\Security\FakeAuthencationStateHandler;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class SamlInteractionProviderTest extends TestCase
+{
+    use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    private readonly ServiceProvider $serviceProvider;
+    private readonly IdentityProvider $identityProvider;
+    private readonly RedirectBinding $redirectBinding;
+    private readonly PostBinding $postBinding;
+    private readonly SamlAuthenticationStateHandler $samlAuthenticationStateHandler;
+    private readonly SamlInteractionProvider $samlInteractionProvider;
+    public function setUp(): void
+    {
+        $this->serviceProvider = Mockery::mock(ServiceProvider::class);
+        $this->identityProvider = Mockery::mock(IdentityProvider::class);
+        $this->redirectBinding = Mockery::mock(RedirectBinding::class);
+        $this->postBinding = Mockery::mock(PostBinding::class);
+
+
+    }
+
+    private function createProvider()
+    {
+        $this->samlInteractionProvider = new SamlInteractionProvider(
+            $this->serviceProvider,
+            $this->identityProvider,
+            $this->redirectBinding,
+            $this->postBinding,
+            $this->samlAuthenticationStateHandler
+        );
+    }
+    public function test_is_saml_authentication_initiated(): void
+    {
+        $this->samlAuthenticationStateHandler = FakeAuthencationStateHandler::createWithRequestId('request-id');
+        $this->createProvider();
+        $this->assertTrue($this->samlInteractionProvider->isSamlAuthenticationInitiated());
+    }
+
+    public function test_is_saml_authentication_not_initiated(): void
+    {
+        $this->samlAuthenticationStateHandler = FakeAuthencationStateHandler::createWithoutRequestId();
+        $this->createProvider();
+        $this->assertFalse($this->samlInteractionProvider->isSamlAuthenticationInitiated());
+    }
+
+    public function test_initiate_saml_request(): void
+    {
+        $this->samlAuthenticationStateHandler = FakeAuthencationStateHandler::createWithoutRequestId();
+        $this->createProvider();
+
+        $privateKey = Mockery::mock(PrivateKey::class);
+        $privateKey->shouldReceive('isFile')->andReturnFalse();
+        $privateKey->shouldReceive('getContents')->andReturn('pk-contents');
+        $privateKey->shouldReceive('getPassPhrase')->andReturn('');
+
+        $this->serviceProvider->shouldReceive('getEntityId')->andReturn('https://sp');
+        $this->serviceProvider->shouldReceive('getAssertionConsumerUrl')->andReturn('https://sp/acs');
+        $this->serviceProvider->shouldReceive('getPrivateKey')->andReturn($privateKey);
+
+        $this->identityProvider->shouldReceive('getSsoUrl')->andReturn('https://idp/sso');
+
+        $redirectResponse = Mockery::mock(RedirectResponse::class);
+        $this->redirectBinding->shouldReceive('createResponseFor')->andReturn($redirectResponse);
+        $response = $this->samlInteractionProvider->initiateSamlRequest();
+
+        $this->assertEquals($response, $redirectResponse);
+    }
+
+    public function test_process_saml_response(): void
+    {
+        $this->samlAuthenticationStateHandler = FakeAuthencationStateHandler::createWithRequestId('req-id');
+        $this->createProvider();
+        $request = Mockery::mock(Request::class);
+        $processedAssertion = Mockery::mock(Assertion::class);
+        $issuer = new Issuer();
+        $issuer->setValue('https://idp');
+        $this->identityProvider->shouldReceive('getEntityId')->andReturn('https://idp');
+        $processedAssertion->shouldReceive('getIssuer')->andReturn($issuer);
+        $this->postBinding->shouldReceive('processResponse')->andReturn($processedAssertion);
+        $assertion = $this->samlInteractionProvider->processSamlResponse($request);
+
+        $this->assertEquals($assertion, $processedAssertion);
+    }
+    public function test_process_saml_response_different_issuer(): void
+    {
+        $this->samlAuthenticationStateHandler = FakeAuthencationStateHandler::createWithRequestId('req-id');
+        $this->createProvider();
+        $request = Mockery::mock(Request::class);
+        $processedAssertion = Mockery::mock(Assertion::class);
+        $issuer = new Issuer();
+        $issuer->setValue('https://idp');
+        $this->identityProvider->shouldReceive('getEntityId')->andReturn('https://idp-2');
+        $processedAssertion->shouldReceive('getIssuer')->andReturn($issuer);
+        $this->postBinding->shouldReceive('processResponse')->andReturn($processedAssertion);
+
+        $this->expectException(UnexpectedIssuerException::class);
+        $this->expectExceptionMessage('Expected issuer to be configured remote IdP "https://idp-2", got "https://idp"');
+        $this->samlInteractionProvider->processSamlResponse($request);
+    }
+
+    public function test_reset(): void
+    {
+        $this->samlAuthenticationStateHandler = FakeAuthencationStateHandler::createWithRequestId('req-id');
+        $this->createProvider();
+
+        $this->samlInteractionProvider->reset();
+
+        $this->assertFalse($this->samlAuthenticationStateHandler->hasRequestId());
+        $this->assertEmpty($this->samlAuthenticationStateHandler->getRequestId());
+    }
+}

--- a/src/Tests/Unit/Security/SamlInteractionProviderTest.php
+++ b/src/Tests/Unit/Security/SamlInteractionProviderTest.php
@@ -36,12 +36,12 @@ class SamlInteractionProviderTest extends TestCase
 {
     use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-    private readonly ServiceProvider $serviceProvider;
-    private readonly IdentityProvider $identityProvider;
-    private readonly RedirectBinding $redirectBinding;
-    private readonly PostBinding $postBinding;
-    private readonly SamlAuthenticationStateHandler $samlAuthenticationStateHandler;
-    private readonly SamlInteractionProvider $samlInteractionProvider;
+    private ServiceProvider $serviceProvider;
+    private IdentityProvider $identityProvider;
+    private RedirectBinding $redirectBinding;
+    private PostBinding $postBinding;
+    private SamlAuthenticationStateHandler $samlAuthenticationStateHandler;
+    private SamlInteractionProvider $samlInteractionProvider;
     public function setUp(): void
     {
         $this->serviceProvider = Mockery::mock(ServiceProvider::class);

--- a/src/Tests/Unit/Security/SamlInteractionProviderTest.php
+++ b/src/Tests/Unit/Security/SamlInteractionProviderTest.php
@@ -48,8 +48,6 @@ class SamlInteractionProviderTest extends TestCase
         $this->identityProvider = Mockery::mock(IdentityProvider::class);
         $this->redirectBinding = Mockery::mock(RedirectBinding::class);
         $this->postBinding = Mockery::mock(PostBinding::class);
-
-
     }
 
     private function createProvider()

--- a/src/Value/DateTime.php
+++ b/src/Value/DateTime.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2023 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Value;
+
+use DateInterval;
+use DateTime as CoreDateTime;
+use Surfnet\SamlBundle\Exception\InvalidArgumentException;
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods) due to comparison methods
+ */
+class DateTime
+{
+    /**
+     * This string can also be used with `DateTime::createFromString()`.
+     */
+    public const FORMAT = DATE_ATOM;
+
+    /**
+     * Allows for mocking of time.
+     */
+    private static ?self $now;
+
+    private CoreDateTime $dateTime;
+
+    public static function now(): self
+    {
+        return self::$now ?: new self(new CoreDateTime);
+    }
+
+    /**
+     * @param string $string A date-time string formatted using `self::FORMAT` (eg. '2014-11-26T15:20:43+01:00').
+     */
+    public static function fromString(string $string): self
+    {
+        $dateTime = CoreDateTime::createFromFormat(self::FORMAT, $string);
+
+        if ($dateTime === false) {
+            throw new InvalidArgumentException('Date-time string could not be parsed: is it formatted correctly?');
+        }
+
+        return new self($dateTime);
+    }
+
+    public function __construct(?CoreDateTime $dateTime = null)
+    {
+        $this->dateTime = $dateTime ?: new CoreDateTime();
+    }
+
+    public function add(DateInterval $interval): self
+    {
+        $dateTime = clone $this->dateTime;
+        $dateTime->add($interval);
+
+        return new self($dateTime);
+    }
+
+    public function sub(DateInterval $interval): self
+    {
+        $dateTime = clone $this->dateTime;
+        $dateTime->sub($interval);
+
+        return new self($dateTime);
+    }
+
+    public function comesBefore(DateTime $dateTime): bool
+    {
+        return $this->dateTime < $dateTime->dateTime;
+    }
+
+    public function comesBeforeOrIsEqual(DateTime $dateTime): bool
+    {
+        return $this->dateTime <= $dateTime->dateTime;
+    }
+
+    public function comesAfter(DateTime $dateTime): bool
+    {
+        return $this->dateTime > $dateTime->dateTime;
+    }
+
+    public function comesAfterOrIsEqual(DateTime $dateTime): bool
+    {
+        return $this->dateTime >= $dateTime->dateTime;
+    }
+
+    public function format(string $format): string
+    {
+        $formatted = $this->dateTime->format($format);
+
+        if ($formatted === false) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Given format "%s" is not a valid format for DateTime',
+                    $format
+                )
+            );
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @return string An ISO 8601 representation of this DateTime.
+     */
+    public function __toString(): string
+    {
+        return $this->format(self::FORMAT);
+    }
+}


### PR DESCRIPTION
This authenticator is compatible with the Symfony Security system. It creates a custom Authenticator class. The user must integrate this authenticator in the application. And a custom user provider must be created as this ties into the apolication logic to strongly to facilitate this in the bundle.

Examples where added to EXAMPLES.md and README.md