### PR TITLE
Return null when AuthRequest has no Subject NameID

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -169,7 +169,11 @@ class AuthnRequest
      */
     public function getNameId()
     {
-        return $this->request->getNameId()->getValue();
+        $nameid=$this->request->getNameId();
+        if (null == $nameid) {
+            return null;
+        }
+        return $nameid->getValue();
     }
 
     /**
@@ -177,7 +181,11 @@ class AuthnRequest
      */
     public function getNameIdFormat()
     {
-        return $this->request->getNameId()->getFormat();
+        $nameid=$this->request->getNameId();
+        if (null == $nameid) {
+            return null;
+        }
+        return $nameid->getFormat();
     }
 
     /**

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -164,6 +164,21 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
      * @test
      * @group saml2
      */
+    public function retreiving_nameid_and_format_from_authnrequest_without_subject_returns_null()
+    {
+        $domDocument = DOMDocumentFactory::fromString($this->authRequestNoSubject);
+        $request     = new SAML2AuthnRequest($domDocument->documentElement);
+
+        $authnRequest = AuthnRequest::createNew($request);
+
+        $this->assertEquals(null, $authnRequest->getNameId());
+        $this->assertEquals(null, $authnRequest->getNameIdFormat());
+    }
+
+    /**
+     * @test
+     * @group saml2
+     */
     public function the_acs_url_can_be_retrieved_from_the_authnrequest()
     {
         $domDocument = DOMDocumentFactory::fromString($this->authRequestWithSubject);


### PR DESCRIPTION
When using AuthnRequest::GetNameId() or AuthnRequest::getNameIdFormat() on an AuthnRequest without a Subject these functions used to return null, currently they throw an exception because of a null dereference.
This PR reinstates the old behaviour and adds a test for this scenario.