### PR TITLE
Repair AuthNRequest NameID problem

### DIFF
--- a/.github/daily-security-check.yml
+++ b/.github/daily-security-check.yml
@@ -1,0 +1,91 @@
+---
+name: Daily security check
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      # PHP checks
+      - name: Check for php composer project
+        id: check_composer
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "composer.lock"
+      - name: Run php local security checker
+        if: steps.check_composer.outputs.files_exists == 'true'
+        uses: symfonycorp/security-checker-action@v4
+
+      # node-yarn checks
+      - name: Check for node-yarn project
+        id: check_node_yarn
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "yarn.lock"
+      - name: Setup node
+        if: steps.check_node_yarn.outputs.files_exists == 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: Yarn Audit
+        if: steps.check_node_yarn.outputs.files_exists == 'true'
+        run: yarn audit --level high --groups dependencies optionalDependencies
+
+      # node-npm checks
+      - name: Check for node-npm project
+        id: check_node_npm
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "package.lock"
+      - name: Setup node
+        if: steps.check_node_npm.outputs.files_exists == 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: npm audit
+        if: steps.check_node_npm.outputs.files_exists == 'true'
+        run: npm audit --audit-level=high
+
+      # python checks
+      - name: Check for python project
+        id: check_python
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "requirements.txt"
+      - name: Safety checks Python dependencies
+        if: steps.check_python.outputs.files_exists == 'true'
+        uses: pyupio/safety@2.3.5
+
+      # java checks
+      - name: Check for java maven project
+        id: check_maven
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "pom.xml"
+      - name: Setup java if needed
+        if: steps.check_maven.outputs.files_exists == 'true'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Check java
+        if: steps.check_maven.outputs.files_exists == 'true'
+        run: mvn org.owasp:dependency-check-maven:check
+
+      # Send results
+      - name: Send to Slack if something failed
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: surfconext-nightly-check
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: 'Dependency check failed :crying_cat_face:'
+          SLACK_TITLE: Dependency check wants attention
+          SLACK_USERNAME: NightlySecurityCheck
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -169,7 +169,10 @@ class AuthnRequest
      */
     public function getNameId()
     {
-        return $this->request->getNameId()->getValue();
+        if ($this->request->getNameId()) {
+            return $this->request->getNameId()->getValue();
+        }
+        return null;
     }
 
     /**
@@ -177,7 +180,10 @@ class AuthnRequest
      */
     public function getNameIdFormat()
     {
-        return $this->request->getNameId()->getFormat();
+        if ($this->request->getNameId()) {
+            return $this->request->getNameId()->getFormat();
+        }
+        return null;
     }
 
     /**

--- a/src/Tests/Unit/SAML2/AuthnRequestTest.php
+++ b/src/Tests/Unit/SAML2/AuthnRequestTest.php
@@ -205,6 +205,17 @@ AUTHNREQUEST_IS_PASSIVE_F_AND_FORCE_AUTHN;
         $this->assertTrue($authnRequest->isForceAuthn());
     }
 
+    public function test_name_id_can_be_null()
+    {
+        $domDocument = DOMDocumentFactory::fromString($this->authRequestNoSubject);
+        $request     = new SAML2AuthnRequest($domDocument->documentElement);
+
+        $authnRequest = AuthnRequest::createNew($request);
+
+        $this->assertNull($authnRequest->getNameId());
+        $this->assertNull($authnRequest->getNameIdFormat());
+    }
+
     public function provideIsPassiveAndForceAuthnCombinations()
     {
         return [


### PR DESCRIPTION
1. The name id accessed the nameID from the SAML2 library without heeding the possibility of it not being set. Resulting in a call to `getValue` on null
2. The nightly security checker has been enabled for the project.