### PR TITLE
Make sure no null value is in ignoreUnkownAttributes

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -62,7 +62,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('ignore_unknown_attributes')
                             ->defaultFalse()
                             ->info(
-                                'If the IDP provides atttributes which are not in the dictionary the SAML assertion'
+                                'If the IDP provides attributes which are not in the dictionary the SAML assertion'
                                 . 'will fail with an UnknownUrnException. Unless this value is true.'
                             )
                             ->end()

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -7,7 +7,7 @@ services:
     surfnet_saml.saml.attribute_dictionary:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary
         arguments:
-            - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
+            - false # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration (if defined)
 
     Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary:
         alias: surfnet_saml.saml.attribute_dictionary

--- a/src/SAML2/Attribute/AttributeDictionary.php
+++ b/src/SAML2/Attribute/AttributeDictionary.php
@@ -45,7 +45,7 @@ class AttributeDictionary
         /**
          * Ignore unknown attributes coming from the IDP
          */
-        private $ignoreUnknownAttributes = false
+        private readonly bool $ignoreUnknownAttributes = false
     ) {
     }
 

--- a/src/Tests/Unit/Container/ContainerTest.php
+++ b/src/Tests/Unit/Container/ContainerTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Tests\Unit\Container;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class ContainerTest extends TestCase
+{
+    private ContainerBuilder $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new ContainerBuilder();
+    }
+
+    public function testIgnoreUnknownAttributesDefaultValue(): void
+    {
+        $definition = new Definition(AttributeDictionary::class);
+        $definition->setPublic(true);
+
+        $this->container->setDefinition('attribute.dictionary', $definition);
+
+        $this->container->compile();
+
+        $attributeDictionary = $this->container->get('attribute.dictionary' );
+
+        $this->assertFalse($attributeDictionary->ignoreUnknownAttributes());
+    }
+
+    public function testIgnoreUnknownAttributesExplicitValueToFalse(): void
+    {
+        $definition = new Definition(AttributeDictionary::class);
+        $definition->setPublic(true);
+        $definition->setArguments([false]);
+
+        $this->container->setDefinition('attribute.dictionary', $definition);
+
+        $this->container->compile();
+
+        $attributeDictionary = $this->container->get('attribute.dictionary');
+
+        $this->assertFalse($attributeDictionary->ignoreUnknownAttributes());
+    }
+
+    public function testIgnoreUnknownAttributesExplicitValueToTrue(): void
+    {
+        $definition = new Definition(AttributeDictionary::class);
+        $definition->setPublic(true);
+        $definition->setArguments([true]);
+
+        $this->container->setDefinition('attribute.dictionary', $definition);
+
+        $this->container->compile();
+
+        $attributeDictionary = $this->container->get('attribute.dictionary');
+
+        $this->assertTrue($attributeDictionary->ignoreUnknownAttributes());
+    }
+
+}


### PR DESCRIPTION
In addition to set the correct parameters in Profile, this add some extra safety to make sure the value is never null